### PR TITLE
feat: Moen OAuth2 migration + sleep mode fixes (v1.0.18)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add *)",
+      "Bash(git commit *)"
+    ]
+  }
+}

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -375,7 +375,7 @@ def checkTokenLife() {
 def makeAPIGet(uri, request_type, success_status = [200, 202], root_url = BASE_URL) {
     checkTokenLife()
     uri = (root_url) ? root_url + uri : uri
-    if (logEnable) log.debug "makeAPIGet: ${request_type} ${uri}"
+    if (logEnable) log.debug "makeAPIGet: ${request_type} ${uri} [Bearer ${(state.token as String)?.take(8)}...]"
 
     if (!settings.password) {
         log.error("User is Logged out. Return to the Moen Flo Manager App and login again to resume updates.");
@@ -421,7 +421,7 @@ def makeAPIGet(uri, request_type, success_status = [200, 202], root_url = BASE_U
 }
 
 def makeAPIPost(uri, body, request_type, success_status = [200, 202], root_url = BASE_URL) {
-    if (logEnable) log.debug "makeAPIPost: ${request_type} ${uri}"
+    if (logEnable) log.debug "makeAPIPost: ${request_type} ${uri} [Bearer ${(state.token as String)?.take(8)}...]"
     checkTokenLife()
     uri = (root_url) ? root_url + uri : uri
     if (!settings.password) {

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -103,7 +103,7 @@ def deviceInstaller() {
       paragraph("<i>(Recommended once app is setup and working -- this spreads out load on hub and Moen API otherwise polls happen every polling interval starting on the hour. To see the schedule, check the bottom of the device page.</i>")
       input(name: 'logAutoTimeOut', type: "bool", title: "Automatically cancel logging afer 30 minutes?", required: false, defaultValue: true, submitOnChange: true)
       paragraph('Units: ' + getUnitDisplay() + ' (to change units -- update your settings in the Moen Flo App)')
-      input(name: "btnLogout", type: "button", title: "Logout", backgroundColor: "#cc2d3b", color: "#ffffff")
+      input(name: "btnLogout", type: "button", title: "<span style='color:#ffffff'>Logout</span>", backgroundColor: "#cc2d3b")
     }
     section("<b>Advanced</b>") {
       input(name: "clientId",     type: "string",   title: "OAuth Client ID",     defaultValue: DEFAULT_CLIENT_ID,     required: false)

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -354,16 +354,15 @@ def getDeviceData(deviceId) {
 }
 
 def checkTokenLife() {
-    if (state.tokenExpiration){
-        remainingMinutes = (int)((new Date(state.tokenExpiration).getTime() - new Date().getTime())/1000/60)
+    if (state.tokenExpiration) {
+        remainingMinutes = (int)((state.tokenExpiration - System.currentTimeMillis()) / 1000 / 60)
         if (logEnable) log.info "Moen API Token Life Remaining: ${remainingMinutes} minutes"
-    }
-    else {
+    } else {
         remainingMinutes = 0
     }
-    if (remainingMinutes < 60) {
+    if (remainingMinutes < 5) {
         log.debug("Moen API Token Life Remaining Minutes only ${remainingMinutes} -- refreshing")
-        authenticate()
+        refreshToken()
     }
     return remainingMinutes
 }

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -263,6 +263,41 @@ def authenticate() {
     if (logEnable) log.debug("failure count: ${state.authenticationFailures}")
 }
 
+def refreshToken() {
+    if (!state.refreshToken) {
+        if (logEnable) log.debug("No refresh token — falling back to full login")
+        authenticate()
+        return
+    }
+    if (logEnable) log.debug("refreshToken()")
+    def cid     = settings.clientId     ?: DEFAULT_CLIENT_ID
+    def csecret = settings.clientSecret ?: DEFAULT_CLIENT_SECRET
+    def body = "grant_type=refresh_token" +
+               "&refresh_token=${java.net.URLEncoder.encode(state.refreshToken as String, 'UTF-8')}" +
+               "&client_id=${cid}" +
+               "&client_secret=${csecret}"
+    def headers = ['Content-Type': 'application/x-www-form-urlencoded']
+    try {
+        httpPost([headers: headers, uri: AUTH_URL, body: body]) { response ->
+            if (response?.status == 200) {
+                state.token           = response.data.access_token
+                state.refreshToken    = response.data.refresh_token
+                state.tokenExpiration = System.currentTimeMillis() + ((long)response.data.expires_in * 1000L)
+                state.tokenExpirationDate = new Date(state.tokenExpiration).toString()
+                state.authenticated   = true
+                state.authenticationFailures = 0
+                if (logEnable) log.debug("Token refreshed successfully")
+            } else {
+                log.warn "Token refresh failed (${response?.status}), falling back to full login"
+                authenticate()
+            }
+        }
+    } catch (Exception e) {
+        log.warn "Token refresh exception: ${e}, falling back to full login"
+        authenticate()
+    }
+}
+
 def getUserInfo() {
   if (!state.authenticated) {
       log.info "Skipped Get User Info: Not Logged In"

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -433,7 +433,7 @@ def makeAPIPost(uri, body, request_type, success_status = [200, 202], root_url =
     while (!response?.status && tries < max_tries) {
         def headers = [:]
         headers.put("Content-Type", "application/json")
-        headers.put("Authorization", state.token)
+        headers.put("Authorization", "Bearer ${state.token}")
 
         try {
             httpPostJson([headers: headers, uri: uri, body: body]) { resp -> def msg = ""
@@ -449,8 +449,8 @@ def makeAPIPost(uri, body, request_type, success_status = [200, 202], root_url =
         catch (Exception e) {
             log.error "${request_type} Exception: ${e}"
             if (e.getMessage().contains("Forbidden") || e.getMessage().contains("Unauthorized")) {
-                log.debug "Forbidden/Unauthorized Exception... Refreshing token..."
-                authenticate()
+                log.debug "Forbidden/Unauthorized on ${request_type}, trying token refresh"
+                refreshToken()
             }
         }
         tries++

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -386,7 +386,7 @@ def makeAPIGet(uri, request_type, success_status = [200, 202], root_url = BASE_U
     while (!response?.status && tries < max_tries) {
         def headers = [:]
         headers.put("Content-Type", "application/json")
-        headers.put("Authorization", state.token)
+        headers.put("Authorization", "Bearer ${state.token}")
 
         try {
             httpGet([headers: headers, uri: uri]) { resp -> def msg = ""
@@ -402,11 +402,12 @@ def makeAPIGet(uri, request_type, success_status = [200, 202], root_url = BASE_U
         catch (Exception e) {
             log.error "${request_type} Exception: ${e}"
             if (e.getMessage()?.contains("Forbidden") || e.getMessage()?.contains("Unauthorized")) {
-                log.debug "Forbidden/Unauthorized Exception..."
+                log.debug "Forbidden/Unauthorized on ${request_type}, trying token refresh"
+                refreshToken()
             } else {
                 log.error "${request_type} Failed ${e}"
+                authenticate()
             }
-            authenticate()
         }
         tries++
 

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -40,8 +40,10 @@ import groovy.transform.Field
    "DEFAULT":             "Moen FLO Smart Shutoff Instance"
 ]
 
-@Field final String BASE_URL = 'https://api-gw.meetflo.com/api/v2'
-@Field final String AUTH_URL = 'https://api.meetflo.com/api/v1/users/auth'
+@Field final String BASE_URL             = 'https://api-gw.meetflo.com/api/v2'
+@Field final String AUTH_URL             = 'https://api-gw.meetflo.com/api/v1/oauth2/token'
+@Field final String DEFAULT_CLIENT_ID     = '3baec26f-0e8b-4e1d-84b0-e178f05ea0a5'
+@Field final String DEFAULT_CLIENT_SECRET = '3baec26f-0e8b-4e1d-84b0-e178f05ea0a5'
 
 def mainPage() {
   initialize()
@@ -195,6 +197,20 @@ def uninstalled() {
 
 def getDriverMap() {
     return driverMap;
+}
+
+def extractUserIdFromJwt(String jwt) {
+    try {
+        def payload = jwt.split('\\.')[1]
+        def padding = (4 - payload.length() % 4) % 4
+        def padded = payload + ('=' * padding)
+        def decoded = new String(java.util.Base64.getUrlDecoder().decode(padded))
+        def json = new groovy.json.JsonSlurper().parseText(decoded)
+        return json.userId ?: json.sub
+    } catch (Exception e) {
+        log.error "Failed to extract userId from JWT: ${e}"
+        return null
+    }
 }
 
 def authenticate() {

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -105,6 +105,11 @@ def deviceInstaller() {
       paragraph('Units: ' + getUnitDisplay() + ' (to change units -- update your settings in the Moen Flo App)')
       input(name: "btnLogout", type: "button", title: "Logout", backgroundColor: "#cc2d3b", color: "#ffffff")
     }
+    section("<b>Advanced</b>") {
+      input(name: "clientId",     type: "string",   title: "OAuth Client ID",     defaultValue: DEFAULT_CLIENT_ID,     required: false)
+      input(name: "clientSecret", type: "password", title: "OAuth Client Secret", defaultValue: DEFAULT_CLIENT_SECRET, required: false)
+      paragraph("<i>Only change these if Moen rotates the API credentials.</i>")
+    }
     section("<b>Diagnostics</b>") {
       input(name: "btnInvalidToken", type: "button", title: "Reset Token")
       input(name: "btnClearCaches", type: "button", title: "Reset All Caches")
@@ -574,6 +579,7 @@ void appButtonHandler(btn) {
       break
     case "btnInvalidToken":
       state.token = '9999999999999999'
+      state.refreshToken = null
       break
     case "btnSetupAllDevices":
       setupAllDevices()

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -209,7 +209,7 @@ def extractUserIdFromJwt(String jwt) {
         def payload = jwt.split('\\.')[1]
         def padding = (4 - payload.length() % 4) % 4
         def padded = payload + ('=' * padding)
-        def decoded = new String(java.util.Base64.getUrlDecoder().decode(padded))
+        def decoded = new String(padded.replace('-', '+').replace('_', '/').decodeBase64())
         def json = new groovy.json.JsonSlurper().parseText(decoded)
         return json.userId ?: json.sub
     } catch (Exception e) {

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -220,47 +220,47 @@ def authenticate() {
     if (!password) {
         log.info("Login Skipped: No password")
         state.authenticationFailures = 99
+        return
     }
-    else {
-        if (state.authenticationFailures >= 3) {
-            log.error("Failed to authenticate after three tries. Giving up. Log out and back in to retry.")
-        }
-        
-        def body = [username:username, password:password]
-        def headers = [:]
-        headers.put("Content-Type", "application/json")
-
-        try {
-            httpPostJson([headers: headers, uri: uri, body: body]) { response -> def msg = response?.status
-                if (logEnable) log.debug("Login received response code ${response?.status}")
-                    if (response?.status == 200) {
-                        msg = "Success"
-                        state.token = response.data.token
-                        state.userId = response.data.tokenPayload.user.user_id
-                        state.tokenExpiration = ((long)response.data.timeNow + (long)response.data.tokenExpiration)*1000
-                        state.tokenExpirationDate = new Date(((long)response.data.timeNow + (long)response.data.tokenExpiration)*1000).toString()
-                        state.authenticated = true
-                        state.authenticationFailures = 0
-                    }
-                    else {
-                        log.error "Login Failed: (${response.status}) ${response.data}"
-                        state.authenticated = false
-                        state.authenticationFailures = (state.authenticationFailures >=0 ? state.authenticationFailures + 1 : 0)
-                    }
-              }
-        }
-        catch (Exception e) {
-            log.error "Login exception: ${e}"
-            log.error "Login Failed: Please confirm your Flo Credentials"
-            state.authenticated = false
-            state.authenticationFailures = (state.authenticationFailures >=0 ? state.authenticationFailures + 1 : 0)
-        }
-        if (logEnable) log.debug("failure count: ${state.authenticationFailures}")
-    }
-    if (state.authenticated) {
-        if (logEnable) log.debug("authentication successful")
+    if (state.authenticationFailures >= 3) {
+        log.error("Failed to authenticate after three tries. Giving up. Log out and back in to retry.")
+        return
     }
 
+    def cid     = settings.clientId     ?: DEFAULT_CLIENT_ID
+    def csecret = settings.clientSecret ?: DEFAULT_CLIENT_SECRET
+    def body = "grant_type=password" +
+               "&username=${java.net.URLEncoder.encode(username as String, 'UTF-8')}" +
+               "&password=${java.net.URLEncoder.encode(password as String, 'UTF-8')}" +
+               "&client_id=${cid}" +
+               "&client_secret=${csecret}"
+    def headers = ['Content-Type': 'application/x-www-form-urlencoded']
+
+    try {
+        httpPost([headers: headers, uri: uri, body: body]) { response ->
+            if (logEnable) log.debug("Login received response code ${response?.status}")
+            if (response?.status == 200) {
+                state.token            = response.data.access_token
+                state.refreshToken     = response.data.refresh_token
+                state.tokenExpiration  = System.currentTimeMillis() + ((long)response.data.expires_in * 1000L)
+                state.tokenExpirationDate = new Date(state.tokenExpiration).toString()
+                state.userId           = extractUserIdFromJwt(state.token as String)
+                state.authenticated    = true
+                state.authenticationFailures = 0
+                if (logEnable) log.debug("authentication successful, userId: ${state.userId}")
+            } else {
+                log.error "Login Failed: (${response?.status}) ${response?.data}"
+                state.authenticated = false
+                state.authenticationFailures = (state.authenticationFailures >= 0 ? state.authenticationFailures + 1 : 0)
+            }
+        }
+    } catch (Exception e) {
+        log.error "Login exception: ${e}"
+        log.error "Login Failed: Please confirm your Flo Credentials"
+        state.authenticated = false
+        state.authenticationFailures = (state.authenticationFailures >= 0 ? state.authenticationFailures + 1 : 0)
+    }
+    if (logEnable) log.debug("failure count: ${state.authenticationFailures}")
 }
 
 def getUserInfo() {

--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -247,7 +247,7 @@ def authenticate() {
             if (response?.status == 200) {
                 state.token            = response.data.access_token
                 state.refreshToken     = response.data.refresh_token
-                state.tokenExpiration  = System.currentTimeMillis() + ((long)response.data.expires_in * 1000L)
+                state.tokenExpiration  = now() + ((long)response.data.expires_in * 1000L)
                 state.tokenExpirationDate = new Date(state.tokenExpiration).toString()
                 state.userId           = extractUserIdFromJwt(state.token as String)
                 state.authenticated    = true
@@ -287,7 +287,7 @@ def refreshToken() {
             if (response?.status == 200) {
                 state.token           = response.data.access_token
                 state.refreshToken    = response.data.refresh_token
-                state.tokenExpiration = System.currentTimeMillis() + ((long)response.data.expires_in * 1000L)
+                state.tokenExpiration = now() + ((long)response.data.expires_in * 1000L)
                 state.tokenExpirationDate = new Date(state.tokenExpiration).toString()
                 state.authenticated   = true
                 state.authenticationFailures = 0
@@ -360,7 +360,7 @@ def getDeviceData(deviceId) {
 
 def checkTokenLife() {
     if (state.tokenExpiration) {
-        remainingMinutes = (int)((state.tokenExpiration - System.currentTimeMillis()) / 1000 / 60)
+        remainingMinutes = (int)((state.tokenExpiration - now()) / 1000 / 60)
         if (logEnable) log.info "Moen API Token Life Remaining: ${remainingMinutes} minutes"
     } else {
         remainingMinutes = 0

--- a/MoenFloManager/apps/MoenLocationInstance.groovy
+++ b/MoenFloManager/apps/MoenLocationInstance.groovy
@@ -73,9 +73,10 @@ def settingsPage() {
       paragraph("<b>Polling Start Minute:</b>&nbsp;<span>${state.startMinute}</span>")
       input(
         name: "revertMinutes",
-        type: "number",
-        title: "Revert Time in Minutes (after Sleep)",
-        defaultValue: 120)
+        type: "enum",
+        title: "Revert Time (after Sleep)",
+        options: ["120": "2 hours", "1440": "24 hours", "4320": "72 hours"],
+        defaultValue: "120")
       input(
         name: "subscribeHSMAway", 
         type: "bool",

--- a/MoenFloManager/drivers/MoenLocation.groovy
+++ b/MoenFloManager/drivers/MoenLocation.groovy
@@ -84,8 +84,8 @@ def setMode(mode) {
     def uri = "/locations/${locationId}/systemMode"
     def body = [target:mode]
     if (mode == "sleep") {
-        body.put("revertMinutes", parent?.revertMinutes)
-        body.put("revertMode", parent?.revertMode)
+        body.put("revertMinutes", (parent?.revertMinutes ?: 120) as Integer)
+        body.put("revertMode", parent?.revertMode ?: "home")
     }
     def response = parent.makeAPIPost(uri, body, "Mode Update", [204])
     sendEvent(name: "mode", value: mode)

--- a/MoenFloManager/packageManifest.json
+++ b/MoenFloManager/packageManifest.json
@@ -4,7 +4,7 @@
   "version": "1.0.18",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2026-06-05",
-  "releaseNotes": "v1.0.18: Migrates to Moen OAuth2 API. Existing installs self-heal on first poll — no manual reauthentication required. Fixes sleep mode 400 error. Sleep revert time now restricted to valid values (2h/24h/72h).\n\nSee full release notes at https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#release-notes",
+  "releaseNotes": "v1.0.18: Migrates to Moen OAuth2 API. Existing installs self-heal on first poll — no manual reauthentication required. Fixes sleep mode 400 error. Sleep revert time restricted to valid values (2h/24h/72h). Fixes logout button text color.\n\nSee full release notes at https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#release-notes",
   "communityLink": "https://community.hubitat.com/t/moen-flo-virtual-device/9677",
   "documentationLink": "https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#readme",
   "licenseFile": "https://raw.githubusercontent.com/dacmanj/hubitat/main/MoenFloManager/license.txt",

--- a/MoenFloManager/packageManifest.json
+++ b/MoenFloManager/packageManifest.json
@@ -1,9 +1,9 @@
 {
   "packageName": "Moen FLO Device Manager",
   "author": "David Manuel",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "minimumHEVersion": "2.1.9",
-  "dateReleased": "2022-11-08",
+  "dateReleased": "2026-06-05",
   "releaseNotes": "Reminder: Always test your devices after an upgrade (especially critical functions like opening/closing shutoff values.)\n\nSee release notes at https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#release-notes",
   "communityLink": "https://community.hubitat.com/t/moen-flo-virtual-device/9677",
   "documentationLink": "https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#readme",

--- a/MoenFloManager/packageManifest.json
+++ b/MoenFloManager/packageManifest.json
@@ -4,7 +4,7 @@
   "version": "1.0.18",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2026-06-05",
-  "releaseNotes": "Reminder: Always test your devices after an upgrade (especially critical functions like opening/closing shutoff values.)\n\nSee release notes at https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#release-notes",
+  "releaseNotes": "v1.0.18: Migrates to Moen OAuth2 API. Existing installs self-heal on first poll — no manual reauthentication required. Fixes sleep mode 400 error. Sleep revert time now restricted to valid values (2h/24h/72h).\n\nSee full release notes at https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#release-notes",
   "communityLink": "https://community.hubitat.com/t/moen-flo-virtual-device/9677",
   "documentationLink": "https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#readme",
   "licenseFile": "https://raw.githubusercontent.com/dacmanj/hubitat/main/MoenFloManager/license.txt",

--- a/MoenFloManager/readme.md
+++ b/MoenFloManager/readme.md
@@ -48,6 +48,8 @@ All trademarks are reserved to their respective owners.
   - Fix sleep mode returning 400 error when revert settings had not been explicitly saved
   - Restrict sleep mode revert time to valid API values: 2 hours, 24 hours, or 72 hours
   - Add optional advanced settings for custom OAuth client ID/secret
+  - Fix logout button text color
+  - Add Bearer token prefix to debug log output for API calls
 
 - 2022-07-16 - v1.0.13
   - Fix release note date from v1.0.12

--- a/MoenFloManager/readme.md
+++ b/MoenFloManager/readme.md
@@ -41,6 +41,14 @@ This project is not affiliated with, endorsed or sponsored by Moen Inc nor Flo T
 
 All trademarks are reserved to their respective owners.
 ## Release Notes
+- 2026-06-05 - v1.0.18
+  - Migrate authentication to Moen OAuth2 API (`/api/v1/oauth2/token`), replacing the deprecated login endpoint
+  - Add token refresh using OAuth2 refresh token with automatic fallback to full re-authentication
+  - Existing installs self-heal on first poll after upgrade — no manual reauthentication required
+  - Fix sleep mode returning 400 error when revert settings had not been explicitly saved
+  - Restrict sleep mode revert time to valid API values: 2 hours, 24 hours, or 72 hours
+  - Add optional advanced settings for custom OAuth client ID/secret
+
 - 2022-07-16 - v1.0.13
   - Fix release note date from v1.0.12
   - Remove stray debug log statement from location device driver

--- a/deploy.js
+++ b/deploy.js
@@ -20,7 +20,7 @@ function findEntry(relpath) {
   if (!hub) { console.error(`No .hubitat.json entry for hub ${HUB_HOST}`); return null; }
   const entry = hub[relpath];
   if (!entry) return null;
-  const type = relpath.split('/')[0].replace(/s$/, ''); // "drivers" → "driver"
+  const type = relpath.split('/')[1].replace(/s$/, ''); // "apps" → "app", "drivers" → "driver"
   return { type, id: entry.id };
 }
 

--- a/deploy.js
+++ b/deploy.js
@@ -35,7 +35,7 @@ function get(endpoint) {
   });
 }
 
-function post(endpoint, body) {
+function post(endpoint, body, contentType = 'application/x-www-form-urlencoded') {
   return new Promise((resolve, reject) => {
     const parsed = new URL(endpoint);
     const data = Buffer.from(body, 'utf8');
@@ -44,7 +44,7 @@ function post(endpoint, body) {
       port:     parsed.port || 80,
       path:     parsed.pathname,
       method:   'POST',
-      headers:  { 'Content-Type': 'application/json', 'Content-Length': data.length },
+      headers:  { 'Content-Type': contentType, 'Content-Length': data.length },
     }, (res) => {
       let buf = '';
       res.on('data', chunk => buf += chunk);
@@ -71,11 +71,12 @@ async function deploy(filepath) {
     }
     const { version } = JSON.parse(cur.body)[0];
     const source  = fs.readFileSync(filepath, 'utf8');
-    const payload = JSON.stringify({ id, source, version });
+    const payload = new URLSearchParams({ id: String(id), source, version: String(version) }).toString();
 
-    const res = await post(`${HUB_URL}/${type}/saveOrUpdateJson`, payload);
+    const res = await post(`${HUB_URL}/${type}/ajax/update`, payload);
     if (res.status >= 200 && res.status < 300) {
-      console.log(`[${type}] ${relpath} → v${version + 1} deployed`);
+      const newVersion = (() => { try { return JSON.parse(res.body).version; } catch { return version + 1; } })();
+      console.log(`[${type}] ${relpath} → v${newVersion} deployed`);
     } else {
       console.error(`[${type}] ${relpath} → FAILED HTTP ${res.status}: ${res.body}`);
     }

--- a/deploy.js
+++ b/deploy.js
@@ -74,11 +74,12 @@ async function deploy(filepath) {
     const payload = new URLSearchParams({ id: String(id), source, version: String(version) }).toString();
 
     const res = await post(`${HUB_URL}/${type}/ajax/update`, payload);
-    if (res.status >= 200 && res.status < 300) {
-      const newVersion = (() => { try { return JSON.parse(res.body).version; } catch { return version + 1; } })();
-      console.log(`[${type}] ${relpath} → v${newVersion} deployed`);
+    let result;
+    try { result = JSON.parse(res.body); } catch { result = {}; }
+    if (res.status >= 200 && res.status < 300 && result.status !== 'error') {
+      console.log(`[${type}] ${relpath} → v${result.version ?? version + 1} deployed`);
     } else {
-      console.error(`[${type}] ${relpath} → FAILED HTTP ${res.status}: ${res.body}`);
+      console.error(`[${type}] ${relpath} → FAILED (HTTP ${res.status}): ${result.errorMessage ?? res.body}`);
     }
   } catch (err) {
     console.error(`[${type}] ${relpath} → ERROR: ${err.message}`);

--- a/deploy.js
+++ b/deploy.js
@@ -86,11 +86,15 @@ async function deploy(filepath) {
   }
 }
 
-const pending = new Map();
-
-chokidar.watch('**/*.groovy', { ignoreInitial: true }).on('change', filepath => {
-  clearTimeout(pending.get(filepath));
-  pending.set(filepath, setTimeout(() => deploy(filepath), 300));
-});
-
-console.log(`Watching **/*.groovy — hub: ${HUB_URL}`);
+if (process.argv.includes('--all')) {
+  const hub = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'))[HUB_HOST];
+  if (!hub) { console.error(`No .hubitat.json entry for hub ${HUB_HOST}`); process.exit(1); }
+  Promise.all(Object.keys(hub).map(relpath => deploy(path.join(__dirname, relpath))));
+} else {
+  const pending = new Map();
+  chokidar.watch('**/*.groovy', { ignoreInitial: true }).on('change', filepath => {
+    clearTimeout(pending.get(filepath));
+    pending.set(filepath, setTimeout(() => deploy(filepath), 300));
+  });
+  console.log(`Watching **/*.groovy — hub: ${HUB_URL}`);
+}

--- a/docs/superpowers/plans/2026-06-04-moen-oauth2-migration.md
+++ b/docs/superpowers/plans/2026-06-04-moen-oauth2-migration.md
@@ -1,0 +1,436 @@
+# Moen OAuth2 API Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `MoenFloManager` from the deprecated Moen password auth endpoint to the new OAuth2 password/refresh-token flow, with Bearer header and 401-hardened retry logic.
+
+**Architecture:** All changes are in one file — `MoenFloManager/apps/MoenDeviceManager.groovy`. No drivers or child apps change; they already delegate all HTTP through `makeAPIGet`/`makeAPIPost`. The OAuth2 flow replaces bare-token auth with access + refresh tokens. All `/api/v2/` data endpoints are unchanged.
+
+**Tech Stack:** Groovy (Hubitat), `java.util.Base64` (JWT decode), `java.net.URLEncoder` (form encoding), Hubitat `httpPost`/`httpGet`
+
+**Spec:** `docs/superpowers/specs/2026-06-04-moen-oauth2-migration-design.md`
+
+---
+
+## File Map
+
+| File | Changes |
+|------|---------|
+| `MoenFloManager/apps/MoenDeviceManager.groovy` | Constants, new helpers/methods, updated auth/HTTP methods, settings UI |
+
+---
+
+### Task 1: Update constants and add JWT decode helper
+
+**Files:**
+- Modify: `MoenFloManager/apps/MoenDeviceManager.groovy`
+
+- [ ] **Step 1: Replace the two `AUTH_URL`/`BASE_URL` constant lines (43–44) with updated auth URL and new client credential defaults**
+
+Replace:
+```groovy
+@Field final String BASE_URL = 'https://api-gw.meetflo.com/api/v2'
+@Field final String AUTH_URL = 'https://api.meetflo.com/api/v1/users/auth'
+```
+With:
+```groovy
+@Field final String BASE_URL             = 'https://api-gw.meetflo.com/api/v2'
+@Field final String AUTH_URL             = 'https://api-gw.meetflo.com/api/v1/oauth2/token'
+@Field final String DEFAULT_CLIENT_ID     = '3baec26f-0e8b-4e1d-84b0-e178f05ea0a5'
+@Field final String DEFAULT_CLIENT_SECRET = '3baec26f-0e8b-4e1d-84b0-e178f05ea0a5'
+```
+
+- [ ] **Step 2: Add `extractUserIdFromJwt()` helper method**
+
+Add this method anywhere before `authenticate()` (e.g. just before the `authenticate()` definition at line ~200):
+```groovy
+def extractUserIdFromJwt(String jwt) {
+    try {
+        def payload = jwt.split('\\.')[1]
+        def padding = (4 - payload.length() % 4) % 4
+        def padded = payload + ('=' * padding)
+        def decoded = new String(java.util.Base64.getUrlDecoder().decode(padded))
+        def json = new groovy.json.JsonSlurper().parseText(decoded)
+        return json.userId ?: json.sub
+    } catch (Exception e) {
+        log.error "Failed to extract userId from JWT: ${e}"
+        return null
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add MoenFloManager/apps/MoenDeviceManager.groovy
+git commit -m "feat: update auth URL constants and add JWT decode helper"
+```
+
+---
+
+### Task 2: Rewrite `authenticate()` for OAuth2 password grant
+
+**Files:**
+- Modify: `MoenFloManager/apps/MoenDeviceManager.groovy`
+
+The current `authenticate()` (lines ~200–248) POSTs JSON to the old endpoint and reads `tokenPayload.user.user_id`. Replace it entirely.
+
+- [ ] **Step 1: Replace the full `authenticate()` method body**
+
+Replace the entire `authenticate()` method with:
+```groovy
+def authenticate() {
+    state.authenticated = false
+    if (logEnable) log.debug("authenticate()")
+    def uri = AUTH_URL
+    if (!password) {
+        log.info("Login Skipped: No password")
+        state.authenticationFailures = 99
+        return
+    }
+    if (state.authenticationFailures >= 3) {
+        log.error("Failed to authenticate after three tries. Giving up. Log out and back in to retry.")
+        return
+    }
+
+    def cid     = settings.clientId     ?: DEFAULT_CLIENT_ID
+    def csecret = settings.clientSecret ?: DEFAULT_CLIENT_SECRET
+    def body = "grant_type=password" +
+               "&username=${java.net.URLEncoder.encode(username as String, 'UTF-8')}" +
+               "&password=${java.net.URLEncoder.encode(password as String, 'UTF-8')}" +
+               "&client_id=${cid}" +
+               "&client_secret=${csecret}"
+    def headers = ['Content-Type': 'application/x-www-form-urlencoded']
+
+    try {
+        httpPost([headers: headers, uri: uri, body: body]) { response ->
+            if (logEnable) log.debug("Login received response code ${response?.status}")
+            if (response?.status == 200) {
+                state.token            = response.data.access_token
+                state.refreshToken     = response.data.refresh_token
+                state.tokenExpiration  = System.currentTimeMillis() + ((long)response.data.expires_in * 1000L)
+                state.tokenExpirationDate = new Date(state.tokenExpiration).toString()
+                state.userId           = extractUserIdFromJwt(state.token as String)
+                state.authenticated    = true
+                state.authenticationFailures = 0
+                if (logEnable) log.debug("authentication successful, userId: ${state.userId}")
+            } else {
+                log.error "Login Failed: (${response?.status}) ${response?.data}"
+                state.authenticated = false
+                state.authenticationFailures = (state.authenticationFailures >= 0 ? state.authenticationFailures + 1 : 0)
+            }
+        }
+    } catch (Exception e) {
+        log.error "Login exception: ${e}"
+        log.error "Login Failed: Please confirm your Flo Credentials"
+        state.authenticated = false
+        state.authenticationFailures = (state.authenticationFailures >= 0 ? state.authenticationFailures + 1 : 0)
+    }
+    if (logEnable) log.debug("failure count: ${state.authenticationFailures}")
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add MoenFloManager/apps/MoenDeviceManager.groovy
+git commit -m "feat: rewrite authenticate() for OAuth2 password grant"
+```
+
+---
+
+### Task 3: Add `refreshToken()` method
+
+**Files:**
+- Modify: `MoenFloManager/apps/MoenDeviceManager.groovy`
+
+- [ ] **Step 1: Add `refreshToken()` immediately after `authenticate()`**
+
+```groovy
+def refreshToken() {
+    if (!state.refreshToken) {
+        if (logEnable) log.debug("No refresh token — falling back to full login")
+        authenticate()
+        return
+    }
+    if (logEnable) log.debug("refreshToken()")
+    def cid     = settings.clientId     ?: DEFAULT_CLIENT_ID
+    def csecret = settings.clientSecret ?: DEFAULT_CLIENT_SECRET
+    def body = "grant_type=refresh_token" +
+               "&refresh_token=${java.net.URLEncoder.encode(state.refreshToken as String, 'UTF-8')}" +
+               "&client_id=${cid}" +
+               "&client_secret=${csecret}"
+    def headers = ['Content-Type': 'application/x-www-form-urlencoded']
+    try {
+        httpPost([headers: headers, uri: AUTH_URL, body: body]) { response ->
+            if (response?.status == 200) {
+                state.token           = response.data.access_token
+                state.refreshToken    = response.data.refresh_token
+                state.tokenExpiration = System.currentTimeMillis() + ((long)response.data.expires_in * 1000L)
+                state.tokenExpirationDate = new Date(state.tokenExpiration).toString()
+                state.authenticated   = true
+                state.authenticationFailures = 0
+                if (logEnable) log.debug("Token refreshed successfully")
+            } else {
+                log.warn "Token refresh failed (${response?.status}), falling back to full login"
+                authenticate()
+            }
+        }
+    } catch (Exception e) {
+        log.warn "Token refresh exception: ${e}, falling back to full login"
+        authenticate()
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add MoenFloManager/apps/MoenDeviceManager.groovy
+git commit -m "feat: add refreshToken() with fallback to full login"
+```
+
+---
+
+### Task 4: Update `checkTokenLife()`
+
+**Files:**
+- Modify: `MoenFloManager/apps/MoenDeviceManager.groovy`
+
+- [ ] **Step 1: Replace `checkTokenLife()` body**
+
+Replace the entire `checkTokenLife()` method with:
+```groovy
+def checkTokenLife() {
+    if (state.tokenExpiration) {
+        remainingMinutes = (int)((state.tokenExpiration - System.currentTimeMillis()) / 1000 / 60)
+        if (logEnable) log.info "Moen API Token Life Remaining: ${remainingMinutes} minutes"
+    } else {
+        remainingMinutes = 0
+    }
+    if (remainingMinutes < 5) {
+        log.debug("Moen API Token Life Remaining Minutes only ${remainingMinutes} -- refreshing")
+        refreshToken()
+    }
+    return remainingMinutes
+}
+```
+
+Key changes from original:
+- Expiry calculation no longer wraps `state.tokenExpiration` in `new Date(...).getTime()` (it's already ms since epoch)
+- Threshold: 60 min → 5 min
+- Calls `refreshToken()` instead of `authenticate()`
+
+- [ ] **Step 2: Commit**
+
+```
+git add MoenFloManager/apps/MoenDeviceManager.groovy
+git commit -m "feat: update checkTokenLife() to use refresh token and 5-min threshold"
+```
+
+---
+
+### Task 5: Update `makeAPIGet` — Bearer header and 401 hardening
+
+**Files:**
+- Modify: `MoenFloManager/apps/MoenDeviceManager.groovy`
+
+- [ ] **Step 1: Fix the `Authorization` header line inside the `while` loop**
+
+Find:
+```groovy
+        headers.put("Authorization", state.token)
+```
+Replace with:
+```groovy
+        headers.put("Authorization", "Bearer ${state.token}")
+```
+
+- [ ] **Step 2: Replace the exception handler in `makeAPIGet`**
+
+Find (the entire catch block):
+```groovy
+        catch (Exception e) {
+            log.error "${request_type} Exception: ${e}"
+            if (e.getMessage()?.contains("Forbidden") || e.getMessage()?.contains("Unauthorized")) {
+                log.debug "Forbidden/Unauthorized Exception..."
+            } else {
+                log.error "${request_type} Failed ${e}"
+            }
+            authenticate()
+        }
+```
+Replace with:
+```groovy
+        catch (Exception e) {
+            log.error "${request_type} Exception: ${e}"
+            if (e.getMessage()?.contains("Forbidden") || e.getMessage()?.contains("Unauthorized")) {
+                log.debug "Forbidden/Unauthorized on ${request_type}, trying token refresh"
+                refreshToken()
+            } else {
+                log.error "${request_type} Failed ${e}"
+                authenticate()
+            }
+        }
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add MoenFloManager/apps/MoenDeviceManager.groovy
+git commit -m "feat: add Bearer prefix and 401 hardening in makeAPIGet"
+```
+
+---
+
+### Task 6: Update `makeAPIPost` — Bearer header and 401 hardening
+
+**Files:**
+- Modify: `MoenFloManager/apps/MoenDeviceManager.groovy`
+
+- [ ] **Step 1: Fix the `Authorization` header line inside the `while` loop**
+
+In `makeAPIPost`, find the same pattern:
+```groovy
+        headers.put("Authorization", state.token)
+```
+Replace with:
+```groovy
+        headers.put("Authorization", "Bearer ${state.token}")
+```
+
+- [ ] **Step 2: Replace the exception handler in `makeAPIPost`**
+
+Find:
+```groovy
+        catch (Exception e) {
+            log.error "${request_type} Exception: ${e}"
+            if (e.getMessage().contains("Forbidden") || e.getMessage().contains("Unauthorized")) {
+                log.debug "Forbidden/Unauthorized Exception... Refreshing token..."
+                authenticate()
+            }
+        }
+```
+Replace with:
+```groovy
+        catch (Exception e) {
+            log.error "${request_type} Exception: ${e}"
+            if (e.getMessage().contains("Forbidden") || e.getMessage().contains("Unauthorized")) {
+                log.debug "Forbidden/Unauthorized on ${request_type}, trying token refresh"
+                refreshToken()
+            }
+        }
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add MoenFloManager/apps/MoenDeviceManager.groovy
+git commit -m "feat: add Bearer prefix and 401 hardening in makeAPIPost"
+```
+
+---
+
+### Task 7: Advanced settings UI and `btnInvalidToken` cleanup
+
+**Files:**
+- Modify: `MoenFloManager/apps/MoenDeviceManager.groovy`
+
+- [ ] **Step 1: Add Advanced settings section to `deviceInstaller()`**
+
+In `deviceInstaller()`, add a new section after the existing `"<b>Settings</b>"` section and before `"<b>Diagnostics</b>"`:
+```groovy
+    section("<b>Advanced</b>") {
+      input(name: "clientId",     type: "string",   title: "OAuth Client ID",     defaultValue: DEFAULT_CLIENT_ID,     required: false)
+      input(name: "clientSecret", type: "password", title: "OAuth Client Secret", defaultValue: DEFAULT_CLIENT_SECRET, required: false)
+      paragraph("<i>Only change these if Moen rotates the API credentials.</i>")
+    }
+```
+
+- [ ] **Step 2: Update `btnInvalidToken` handler to also clear the refresh token**
+
+Find:
+```groovy
+    case "btnInvalidToken":
+      state.token = '9999999999999999'
+      break
+```
+Replace with:
+```groovy
+    case "btnInvalidToken":
+      state.token = '9999999999999999'
+      state.refreshToken = null
+      break
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add MoenFloManager/apps/MoenDeviceManager.groovy
+git commit -m "feat: add advanced OAuth credential settings; clear refresh token on reset"
+```
+
+---
+
+### Task 8: Upload to hub and verify
+
+**Files:**
+- Read: `.env` (or pass args directly)
+
+This is a Groovy app running on Hubitat — there is no local test runner. Verification is done by uploading and observing live logs.
+
+- [ ] **Step 1: Upload to hub**
+
+```
+python tools/uploader.py MoenFloManager upload
+```
+Expected output: all 7 files uploaded successfully with 200 responses.
+
+- [ ] **Step 2: Trigger a full re-login to test OAuth2 password grant**
+
+In the Hubitat UI, open the **Moen FLO Device Manager** app. Click **Logout**, then re-enter credentials and click **Login**.
+
+In Hubitat logs, expect to see:
+```
+[debug] authenticate()
+[debug] Login received response code 200
+[debug] authentication successful, userId: <uuid>
+```
+And NOT any error like "Login Failed".
+
+- [ ] **Step 3: Verify Bearer header works — confirm a successful device poll**
+
+In the Hubitat UI, open any child device (e.g. Smart Shutoff valve) and click **Poll** (or wait for the next scheduled poll).
+
+In logs, expect:
+```
+[debug] makeAPIGet: Get Device https://api-gw.meetflo.com/api/v2/devices/<id>
+[debug] Get Device Received Response Code: 200
+```
+No 401/403 errors.
+
+- [ ] **Step 4: Verify refresh token path — use "Reset Token" diagnostic**
+
+In the app settings, click **Reset Token** (the `btnInvalidToken` button). This sets `state.token` to a junk value and clears `state.refreshToken`. Then trigger a poll from any device.
+
+In logs, expect:
+```
+[debug] Forbidden/Unauthorized on Get Device, trying token refresh
+[debug] No refresh token — falling back to full login
+[debug] authentication successful, userId: <uuid>
+[debug] Get Device Received Response Code: 200
+```
+The poll recovers automatically without user intervention.
+
+- [ ] **Step 5: Verify advanced settings appear in UI**
+
+In the app settings UI, scroll to the new **Advanced** section. Confirm **OAuth Client ID** and **OAuth Client Secret** fields appear pre-filled with the default UUID.
+
+- [ ] **Step 6: Commit a version bump**
+
+In `MoenFloManager/packageManifest.json` and each Groovy file's `version` metadata field, bump the version (e.g. `1.0.17` → `1.0.18`).
+
+```
+git add MoenFloManager/
+git commit -m "bump version to 1.0.18; migrate to OAuth2 auth"
+```

--- a/docs/superpowers/specs/2026-06-04-moen-oauth2-migration-design.md
+++ b/docs/superpowers/specs/2026-06-04-moen-oauth2-migration-design.md
@@ -1,0 +1,145 @@
+# Design: Moen Flo OAuth2 API Migration
+
+**Date:** 2026-06-04  
+**Scope:** `MoenFloManager` only — `MoenFloStandalone` is unchanged.
+
+---
+
+## Background
+
+Moen deprecated their old auth endpoint (`POST https://api.meetflo.com/api/v1/users/auth`). The replacement is a standard OAuth2 password/refresh-token flow at `POST https://api-gw.meetflo.com/api/v1/oauth2/token`. All `/api/v2/` data endpoints are unchanged.
+
+---
+
+## Scope
+
+**One file changes:** `MoenFloManager/apps/MoenDeviceManager.groovy`
+
+No drivers or child apps change — they already delegate all HTTP calls to the parent app via `makeAPIGet`/`makeAPIPost`.
+
+---
+
+## Design
+
+### 1. Constants
+
+Replace the old `AUTH_URL` and add OAuth client credential defaults:
+
+```groovy
+@Field final String AUTH_URL             = 'https://api-gw.meetflo.com/api/v1/oauth2/token'
+@Field final String DEFAULT_CLIENT_ID     = '3baec26f-0e8b-4e1d-84b0-e178f05ea0a5'
+@Field final String DEFAULT_CLIENT_SECRET = '3baec26f-0e8b-4e1d-84b0-e178f05ea0a5'
+```
+
+`BASE_URL` is unchanged (`https://api-gw.meetflo.com/api/v2`).
+
+---
+
+### 2. Settings UI
+
+Add an **Advanced** section at the bottom of `deviceInstaller()`:
+
+- `clientId` — string input, pre-filled with `DEFAULT_CLIENT_ID`
+- `clientSecret` — password input, pre-filled with `DEFAULT_CLIENT_SECRET`
+- Helper note: *"Only change these if Moen rotates the API credentials."*
+
+---
+
+### 3. State
+
+| Key | Old | New |
+|-----|-----|-----|
+| `state.token` | Bare JWT from old auth | `access_token` from OAuth2 response |
+| `state.refreshToken` | (did not exist) | `refresh_token` from OAuth2 response |
+| `state.userId` | `response.data.tokenPayload.user.user_id` | Decoded from JWT payload (`userId` claim, fallback `sub`) |
+| `state.tokenExpiration` | `(timeNow + tokenExpiration) * 1000` | `System.currentTimeMillis() + (expires_in * 1000)` |
+
+---
+
+### 4. `authenticate()` — full password login
+
+- **Request:** `POST AUTH_URL`, `Content-Type: application/x-www-form-urlencoded`
+- **Body:** `grant_type=password&username=<url-encoded>&password=<url-encoded>&client_id=<clientId setting or DEFAULT>&client_secret=<clientSecret setting or DEFAULT>`
+- **Response parsing:**
+  - `state.token = response.data.access_token`
+  - `state.refreshToken = response.data.refresh_token`
+  - `state.tokenExpiration = System.currentTimeMillis() + (response.data.expires_in * 1000L)`
+  - `state.userId = extractUserIdFromJwt(state.token)`
+  - `state.authenticated = true`, `state.authenticationFailures = 0`
+- **Failure:** increment `state.authenticationFailures`; guard: give up after 3 failures (same as today)
+
+---
+
+### 5. New `refreshToken()` method
+
+- If `state.refreshToken` is null/empty → call `authenticate()` and return
+- **Request:** same endpoint, `grant_type=refresh_token&refresh_token=<url-encoded>&client_id=...&client_secret=...`
+- **On success (200):** update `state.token`, `state.refreshToken`, `state.tokenExpiration` (userId unchanged)
+- **On any failure** (non-200 or exception): log a warning and fall back to `authenticate()`
+
+---
+
+### 6. New `extractUserIdFromJwt()` helper
+
+```groovy
+def extractUserIdFromJwt(String jwt) {
+    try {
+        def payload = jwt.split('\\.')[1]
+        def decoded = new String(java.util.Base64.getUrlDecoder().decode(payload))
+        def json = new groovy.json.JsonSlurper().parseText(decoded)
+        return json.userId ?: json.sub
+    } catch (Exception e) {
+        log.error "Failed to extract userId from JWT: ${e}"
+        return null
+    }
+}
+```
+
+---
+
+### 7. `checkTokenLife()` changes
+
+- Threshold: 60 min → **5 min**
+- Calls `refreshToken()` instead of `authenticate()`
+- Expiry calculation simplified: `(state.tokenExpiration - System.currentTimeMillis()) / 1000 / 60`
+
+---
+
+### 8. `makeAPIGet` / `makeAPIPost` changes
+
+**Auth header** (both methods):
+```groovy
+// before
+headers.put("Authorization", state.token)
+// after
+headers.put("Authorization", "Bearer ${state.token}")
+```
+
+**401/403 hardening** (exception handlers in both methods): when exception message contains "Forbidden" or "Unauthorized", call `refreshToken()` instead of `authenticate()`. Since `refreshToken()` falls back to `authenticate()` on failure, the net recovery behaviour is the same as today but avoids a full re-login when the token simply expired.
+
+---
+
+### 9. `logout()` / state cleanup
+
+Clear `state.refreshToken` alongside `state.token` on logout and on "Reset Token" diagnostic button press.
+
+---
+
+## Migration / Existing Users
+
+Existing users have an old `state.token` (non-Bearer format) and no `state.refreshToken`. On first API call after upgrade:
+
+1. Old token → API returns 401
+2. Exception handler detects Forbidden/Unauthorized → calls `refreshToken()`
+3. No `state.refreshToken` → `refreshToken()` falls back to `authenticate()`
+4. Full re-login succeeds using saved username/password
+
+No manual intervention required. Password must still be saved in settings (it is, for all existing installs).
+
+---
+
+## Out of Scope
+
+- `MoenFloStandalone` — no changes
+- Data endpoints — all unchanged
+- Child apps and drivers — no changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "hubitat-deploy",
   "private": true,
   "scripts": {
-    "watch": "node deploy.js"
+    "watch": "node deploy.js",
+    "deploy": "node deploy.js --all"
   },
   "dependencies": {
     "chokidar": "^3.6.0",


### PR DESCRIPTION
## Summary
- Rewrites authentication to use the OAuth2 password grant flow (`/api/v1/oauth2/token`), replacing the deprecated login endpoint
- Adds `refreshToken()` with automatic fallback to full re-authentication — transparent upgrade, no manual reauthentication required
- Adds `Bearer` prefix to all API request headers with improved 401/403 handling
- Adds advanced settings for custom OAuth client ID/secret; clears refresh token on manual reset
- Fixes sleep mode 400 error: Hubitat settings return `null` until explicitly saved; defaults to 120 min / "home" when unset
- Restricts sleep revert time to valid API values (2 hours / 24 hours / 72 hours) matching HA integration
- Fixes logout button text showing wrong color (inline HTML style instead of unsupported `color` param)
- Adds Bearer token prefix to debug log output for API calls
- Fixes Hubitat sandbox violations: replaces `java.util.Base64` and `System.currentTimeMillis()` with sandbox-safe equivalents

## Upgrade Notes
Existing installs self-heal: the first API call after upgrade will get a 401, trigger reauthentication via the new OAuth2 flow, and resume normally. No user action required.

## Test Plan
- [x] API calls succeed after upgrade without manual reauthentication
- [x] Valve open/close commands work
- [x] Location mode home/away work
- [x] Sleep mode works (previously returned 400)
- [x] Sleep revert time dropdown shows 2h/24h/72h options
- [x] Debug logs show `Bearer` prefix on API calls
- [x] Logout button text is white on red background
- [x] Use "Reset Token" button to force reauthentication and confirm recovery
- [x] Water detector polling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)