### PR TITLE
Add FordPass Connect package (migrated from dacmanj/ha-fordpass)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Hubitat home automation drivers/apps for the Moen Flo Smart Shutoff valve and Smart Water Detector. The Groovy code runs on a Hubitat hub (not locally); the Python toolset syncs files between this repo and a live hub.
+Hubitat home automation drivers/apps published by David Manuel, distributed via Hubitat Package Manager. Each top-level folder is an independent package with its own `packageManifest.json`. The Groovy code runs on a Hubitat hub (not locally); the Python/Node tooling syncs files between this repo and a live hub.
 
-## Two Packages
+## Packages
 
+- **FordPass/** — Ford/Lincoln connected vehicle integration. `apps/FordPassConnect.groovy` handles OAuth PKCE auth, token management, and polling the Ford/Autonomic APIs; `drivers/FordPassVehicle.groovy` is the child device driver (lock/unlock, remote start, guard mode, preconditioning, vehicle status, optional ABRP live telemetry push). Namespace is `fordpass-hubitat` (not `dacmanj`) — do not change this, it would orphan existing installs. Ported from [marq24/ha-fordpass](https://github.com/marq24/ha-fordpass); originally developed in the `hubitat/` directory of [dacmanj/ha-fordpass](https://github.com/dacmanj/ha-fordpass), which is still useful as a reference when diagnosing Ford API changes (it retains the Python HA integration this was ported from). Licensed under Apache 2.0 (see `FordPass/license.txt`), unlike the Moen packages below.
 - **MoenFloManager/** — Active package. Multi-app architecture: a parent app (`MoenDeviceManager`) manages child app instances (`MoenLocationInstance`, `MoenSmartShutoffInstance`, `MoenSmartWaterDetectorInstance`) and their corresponding drivers. Polls `https://api-gw.meetflo.com/api/v2`.
 - **MoenFloStandalone/** — Legacy standalone driver only. Bug fixes only; no new features.
 
@@ -49,7 +50,7 @@ VS Code tasks (`Terminal > Run Task`) also expose "Upload to Hubitat" and "Retri
 
 ## Groovy / Hubitat Conventions
 
-- Namespace for all files: `dacmanj`
+- Namespace for Moen files: `dacmanj`. FordPass uses `fordpass-hubitat` instead (inherited from its origin as a standalone port) — keep package namespaces as-is rather than unifying them, since changing a namespace breaks existing installs.
 - Device type→driver/app mapping is in `@Field final Map driverMap` / `appMap` in `MoenDeviceManager.groovy`
 - `packageManifest.json` in each package root is what Hubitat Package Manager uses — keep UUIDs stable; bump `version` on releases
 - The Smart Water Detector driver (`MoenSmartWaterDetector.groovy`) is marked `required: false` in the manifest — it's optional

--- a/FordPass/license.txt
+++ b/FordPass/license.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Matthias Marquardt
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/FordPass/packageManifest.json
+++ b/FordPass/packageManifest.json
@@ -1,0 +1,30 @@
+{
+  "packageName": "FordPass Connect",
+  "author": "David Manuel",
+  "version": "1.0.0",
+  "minimumHEVersion": "2.3.0",
+  "dateReleased": "2026-07-24",
+  "releaseNotes": "v1.0.0: Initial release. Hubitat port of marq24/ha-fordpass (Home Assistant integration) — OAuth PKCE auth, vehicle polling, lock/unlock, remote start, guard mode, preconditioning, and optional ABRP (A Better Route Planner) live telemetry push.",
+  "documentationLink": "https://github.com/dacmanj/hubitat/tree/main/FordPass#readme",
+  "licenseFile": "https://raw.githubusercontent.com/dacmanj/hubitat/main/FordPass/license.txt",
+  "apps": [
+    {
+      "id": "d7db8b81-f960-4f6d-a110-8d9125aa0948",
+      "name": "FordPass Connect",
+      "namespace": "fordpass-hubitat",
+      "location": "https://raw.githubusercontent.com/dacmanj/hubitat/main/FordPass/apps/FordPassConnect.groovy",
+      "required": true,
+      "oauth": false,
+      "primary": true
+    }
+  ],
+  "drivers": [
+    {
+      "id": "87f84e38-d13c-4cf1-a381-42fc0ed7435d",
+      "name": "FordPass Vehicle",
+      "namespace": "fordpass-hubitat",
+      "location": "https://raw.githubusercontent.com/dacmanj/hubitat/main/FordPass/drivers/FordPassVehicle.groovy",
+      "required": true
+    }
+  ]
+}

--- a/FordPass/readme.md
+++ b/FordPass/readme.md
@@ -15,11 +15,25 @@ Hubitat port of [marq24/ha-fordpass](https://github.com/marq24/ha-fordpass), bri
 
 ## Installation
 
-Install both files via the Hubitat Package Manager (HPM) or manually:
+### Hubitat Package Manager (recommended)
 
-1. **Drivers Code** → paste `FordPassVehicle.groovy` → Save
-2. **Apps Code** → paste `FordPassConnect.groovy` → Save
-3. **Apps** → **Add User App** → **FordPass Connect**
+[Hubitat Package Manager (HPM)](https://github.com/HubitatCommunity/hubitatpackagemanager) handles installation and future updates automatically.
+
+1. If you don't have HPM installed yet, see the [HPM repo](https://github.com/HubitatCommunity/hubitatpackagemanager) for setup instructions.
+2. Open HPM on your hub and choose **Install**.
+3. Search for **FordPass Connect**.
+4. Follow the prompts to install.
+
+### Manual Installation
+
+Import each file individually via your hub's code editor (**Apps Code** / **Drivers Code** → **New** → **Import** → paste the raw GitHub URL → **Import** → **Save**):
+
+| Type | File | Import URL |
+|---|---|---|
+| Driver | FordPassVehicle | `https://raw.githubusercontent.com/dacmanj/hubitat/main/FordPass/drivers/FordPassVehicle.groovy` |
+| App | FordPassConnect | `https://raw.githubusercontent.com/dacmanj/hubitat/main/FordPass/apps/FordPassConnect.groovy` |
+
+Then: **Apps** → **Add User App** → **FordPass Connect**.
 
 ---
 
@@ -184,3 +198,5 @@ Set the hub's location under **Settings → Location** in Hubitat. The driver co
 ## Credits
 
 Ported from [marq24/ha-fordpass](https://github.com/marq24/ha-fordpass). All API behavior, data structures, and auth flow are derived from that Home Assistant integration.
+
+Originally developed in the `hubitat/` directory of [dacmanj/ha-fordpass](https://github.com/dacmanj/ha-fordpass) (a fork of marq24/ha-fordpass), which cross-references the Home Assistant integration's Python source when diagnosing Ford API changes. Moved here to live alongside this author's other published Hubitat packages; the fork remains useful as a reference when the Ford API changes.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,167 @@
+# FordPass Connect — Hubitat Elevation Port
+
+Hubitat port of [marq24/ha-fordpass](https://github.com/marq24/ha-fordpass), bringing Ford and Lincoln connected vehicle support to Hubitat Elevation.
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `apps/FordPassConnect.groovy` | Hubitat app — OAuth PKCE flow, token management, API polling, child device creation |
+| `drivers/FordPassVehicle.groovy` | Child device driver — parses vehicle data, exposes capabilities and attributes, relays commands |
+
+---
+
+## Installation
+
+Install both files via the Hubitat Package Manager (HPM) or manually:
+
+1. **Drivers Code** → paste `FordPassVehicle.groovy` → Save
+2. **Apps Code** → paste `FordPassConnect.groovy` → Save
+3. **Apps** → **Add User App** → **FordPass Connect**
+
+---
+
+## Setup
+
+The app walks you through four pages:
+
+1. **Main** — status overview; shows token state and last poll time
+2. **Region** — select brand (Ford or Lincoln) and region (USA, Canada, EU, AU, …)
+3. **Auth** — generates a PKCE code challenge, gives you a Ford login URL to open in a browser, and accepts the redirect URL you paste back in
+4. **VIN** — lists vehicles on the account; select one to create the child device
+
+After setup the app polls the Ford/Autonomic APIs on a configurable interval and pushes data to the child device.
+
+---
+
+## Supported Vehicles
+
+Any Ford or Lincoln with an active FordPass or Lincoln Way connectivity subscription. Feature availability varies by vehicle:
+
+| Feature | Petrol/Diesel | PHEV | Full EV |
+|---------|:---:|:---:|:---:|
+| Fuel level / range | ✓ | ✓ | — |
+| Battery SOC / range | — | ✓ | ✓ |
+| Charging status / plug | — | ✓ | ✓ |
+| Remote start | ✓ | ✓ | ✓ |
+| Lock / unlock | ✓ | ✓ | ✓ |
+| Door / window status | ✓ | ✓ | ✓ |
+| Tire pressures | ✓ | ✓ | ✓ |
+| GPS / presence | ✓ | ✓ | ✓ |
+| Guard mode | ✓ (select) | ✓ (select) | ✓ (select) |
+| Preconditioning | — | ✓ | ✓ |
+
+---
+
+## Driver Capabilities & Attributes
+
+### Capabilities
+
+| Capability | Attribute | Values |
+|-----------|-----------|--------|
+| Lock | `lock` | `locked` / `unlocked` |
+| Switch | `switch` | `on` (remote start active) / `off` |
+| PresenceSensor | `presence` | `present` / `not present` |
+| TemperatureMeasurement | `temperature` | outside temp in hub's scale |
+| Refresh | — | triggers immediate poll |
+
+### Custom Attributes
+
+**Distance / range**
+- `odometer` — km or miles (per preference)
+- `fuelLevel` — %
+- `fuelRange` — km or miles
+- `batterySOC` — % (EV/PHEV)
+- `batteryRange` — km or miles (EV/PHEV)
+
+**Tires**
+- `tirePressureFL / FR / RL / RR` — in selected unit
+- `tirePressureUnit` — PSI / kPa / BAR
+
+**Doors** (CLOSED / OPEN / AJAR)
+- `doorStatusDriver / Passenger / RearLeft / RearRight / Hood / Tailgate`
+
+**Windows** (open / closed)
+- `windowStatusDriver / Passenger / RearLeft / RearRight`
+
+**Ignition / security**
+- `ignition` — Off / On / Start / Run
+- `lockState` — LOCKED / PARTLY_LOCKED / UNLOCKED
+- `alarmStatus`
+- `deepSleepMode`
+
+**Fluids / engine**
+- `oilLife` — %
+- `engineOilTemp` / `engineCoolantTemp` — in hub's temperature scale
+
+**EV / charging**
+- `chargingStatus` — NOT_READY / IN_PROGRESS / COMPLETE / PAUSED / SCHEDULED
+- `plugStatus` — CONNECTED / DISCONNECTED / CHARGING
+- `chargingPower` — kW
+- `targetSOC` — %
+
+**GPS**
+- `latitude` / `longitude` / `speed` / `heading`
+- `lastUpdated`
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `lock()` / `unlock()` | Lock or unlock all doors |
+| `remoteStart()` / `cancelRemoteStart()` | Remote engine/climate start |
+| `honkAndFlash()` | Panic cue (honk + lights) |
+| `requestStatusRefresh()` | Tell vehicle to push a fresh status update (can take up to 5 min) |
+| `enableGuardMode()` / `disableGuardMode()` | Guard mode (select vehicles) |
+| `preconditionStart()` / `preconditionStop()` / `preconditionExtend()` | Cabin preconditioning (EV/PHEV) |
+| `refresh()` | Trigger an immediate app poll |
+
+---
+
+## Driver Preferences
+
+| Preference | Default | Notes |
+|-----------|---------|-------|
+| Tire pressure unit | PSI | PSI / kPa / BAR |
+| Distance unit | miles | miles / km |
+| Home geofence radius | 200 m | Radius around hub location for presence detection |
+| Enable debug logging | off | Auto-disables after 2 hours |
+
+### Geofence presence
+
+Set the hub's location under **Settings → Location** in Hubitat. The driver computes the Haversine distance between the vehicle's GPS position and the hub's coordinates; if within the configured radius it reports `present`, otherwise `not present`.
+
+---
+
+## Debugging
+
+1. Enable **"Enable debug logging"** in driver preferences — logs auto-disable after 2 hours.
+2. Open **Hubitat Logs** filtered to the device name.
+3. Unmatched door, window, or tire API values are logged at debug level with the raw `vehicleDoor` / `vehicleWindow` / `vehicleWheel` field values — useful for diagnosing vehicles with non-standard field names (e.g. Mach-E uses `UNSPECIFIED_FRONT` instead of `FRONT_LEFT`).
+
+> **Ford's API is undocumented and changes without warning.** All JSON parsing is defensive — unexpected fields are logged at debug level rather than causing errors.
+
+---
+
+## Token Lifecycle
+
+- **Ford Foundational token** — refreshed automatically before each API call; a background job also runs every 4 minutes as a safety net.
+- **Autonomic token** — exchanged using the Ford token; refreshed on the same schedule.
+- Token state is stored in the app's `state` map and survives hub reboots.
+
+---
+
+## Known Limitations
+
+- No automated tests — all verification requires a real connected vehicle with live Ford API credentials.
+- Guard mode uses a separate Ford MPS endpoint; availability is vehicle-dependent.
+- Preconditioning uses the Ford RCC API; only available on Mach-E and RCC-capable vehicles.
+- `requestStatusRefresh()` asks the vehicle to push an update — the vehicle must have cellular connectivity and may take up to 5 minutes to respond.
+
+---
+
+## Credits
+
+Ported from [marq24/ha-fordpass](https://github.com/marq24/ha-fordpass). All API behavior, data structures, and auth flow are derived from that Home Assistant integration.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ After setup the app polls the Ford/Autonomic APIs on a configurable interval and
 
 ---
 
+## ABRP Live Data (Optional)
+
+The app can push live telemetry to [A Better Route Planner](https://abetterrouteplanner.com) (ABRP)
+on every poll, so ABRP's route/energy predictions use your vehicle's real-time SOC, position, speed,
+and charging state instead of stale data.
+
+Setup:
+
+1. In the ABRP app or abetterrouteplanner.com, open your vehicle → **Live Data** → link it using the
+   **Generic** connection method. ABRP gives you a token.
+2. In the FordPass Connect app's main page, enable **Push live telemetry to ABRP** and paste that
+   token into **ABRP Generic Token**.
+
+Telemetry (SOC, lat/lon, speed, external temperature, charging state) is sent to ABRP's telemetry
+endpoint (`api.iternio.com/1/tlm/send`) right after each scheduled poll — so the ABRP push interval
+matches your **Polling Interval** setting. No separate schedule or child device is created for this.
+
+---
+
 ## Supported Vehicles
 
 Any Ford or Lincoln with an active FordPass or Lincoln Way connectivity subscription. Feature availability varies by vehicle:

--- a/apps/FordPassConnect.groovy
+++ b/apps/FordPassConnect.groovy
@@ -49,8 +49,9 @@ definition(
 @Field String FORD_FOUNDATIONAL_API = "https://api.foundational.ford.com/api"
 @Field String FORD_VEHICLE_API      = "https://api.vehicle.ford.com/api"
 @Field String FORD_MPS_API          = "https://api.mps.ford.com/api"
-@Field String AUTONOMIC_ACCOUNT_URL = "https://accounts.autonomic.ai/v1"
-@Field String AUTONOMIC_API_URL     = "https://api.autonomic.ai/v1"
+@Field String AUTONOMIC_ACCOUNT_URL  = "https://accounts.autonomic.ai/v1"
+@Field String AUTONOMIC_API_URL      = "https://api.autonomic.ai/v1"
+@Field String AUTONOMIC_BETA_API_URL = "https://api.autonomic.ai/v1beta"
 
 // Default HTTP headers matching the FordPass Android app (okhttp/4.12.0)
 @Field Map DEFAULT_HEADERS = [
@@ -903,35 +904,41 @@ Map fetchVehicleStatus(String vin) {
  * Send a command to the vehicle via the Autonomic API.
  *
  * The command name goes in the JSON body as "type" — NOT in the URL path.
- * URL: POST /v1/command/vehicles/{vin}/commands
+ * URL: POST /v1/command/vehicles/{vin}/commands   (or /v1beta/ when version is set)
  * Body: { "type": commandName, "properties": {extra}, "tags": {}, "wakeUp": true }
+ *       Beta commands additionally include "version": version.
  *
  * Mirrors fordpass_bridge.py::__request_and_poll_command_autonomic()
  *
  * commandName: "lock", "unlock", "remoteStart", "cancelRemoteStart",
- *              "statusRefresh", "startPanicCue", etc.
- * props:       optional Map of extra fields merged into "properties" (default: empty)
+ *              "statusRefresh", "startPanicCue",
+ *              "startOnDemandPreconditioning", "extendOnDemandPreconditioning",
+ *              "stopOnDemandPreconditioning", etc.
+ * props:       optional Map merged into "properties" (default: empty)
+ * version:     when non-null, uses AUTONOMIC_BETA_API_URL and includes "version" in body
  */
-boolean sendVehicleCommand(String commandName, Map props = [:]) {
+boolean sendVehicleCommand(String commandName, Map props = [:], String version = null) {
     logDebug("sendVehicleCommand(${commandName})")
     String vin = state.vin
     if (!vin) { logError("sendVehicleCommand: no VIN configured"); return false }
     if (!ensureValidTokens()) { logError("sendVehicleCommand: token refresh failed"); return false }
 
     Map headers = [
-        "Content-Type":   "application/json",
+        "Content-Type":    "application/json",
         "Accept-Encoding": "gzip",
-        "Connection":     "keep-alive",
-        "User-Agent":     "okhttp/4.12.0",
-        "Authorization":  "Bearer ${state.autoToken}",
+        "Connection":      "keep-alive",
+        "User-Agent":      "okhttp/4.12.0",
+        "Authorization":   "Bearer ${state.autoToken}",
     ]
-    String url = "${AUTONOMIC_API_URL}/command/vehicles/${vin}/commands"
+    String baseUrl = (version != null) ? AUTONOMIC_BETA_API_URL : AUTONOMIC_API_URL
+    String url = "${baseUrl}/command/vehicles/${vin}/commands"
     Map bodyMap = [
         properties: props ?: [:],
         tags:       [:],
         type:       commandName,
         wakeUp:     true,
     ]
+    if (version != null) { bodyMap.version = version }
     String bodyJson = JsonOutput.toJson(bodyMap)
 
     boolean success = false
@@ -956,6 +963,100 @@ boolean sendVehicleCommand(String commandName, Map props = [:]) {
         logError("sendVehicleCommand(${commandName}): HTTP ${e.statusCode} — ${errBody ?: e.message}")
     } catch (Exception e) {
         logError("sendVehicleCommand(${commandName}): ${e.message}")
+    }
+    return success
+}
+
+/**
+ * Remote Climate Control (RCC) — Mach-E and other vehicles that support it.
+ *
+ * Two-step flow:
+ *   1. POST rcc/profile/status to read the vehicle's current climate preferences
+ *   2. PUT  rcc/profile/update  to activate ("On") or deactivate ("Off")
+ *
+ * Auth: auth-token + Application-Id (Ford Vehicle API, not Autonomic)
+ * Mirrors fordpass_bridge.py::req_remote_climate() + set_rcc()
+ *
+ * flag: "On" to start preconditioning, "Off" to stop
+ */
+boolean sendRccCommand(String flag) {
+    logDebug("sendRccCommand(${flag})")
+    String vin = state.vin
+    if (!vin) { logError("sendRccCommand: no VIN configured"); return false }
+    if (!ensureValidTokens()) { logError("sendRccCommand: token refresh failed"); return false }
+
+    Map regionCfg = REGIONS[state.region ?: "usa"]
+    Map fordHeaders = API_HEADERS + [
+        "auth-token":     state.fordToken,
+        "Application-Id": regionCfg.app_id,
+    ]
+
+    // Step 1: read current RCC profile to get userPreferences list
+    List userPreferences = []
+    try {
+        httpPost([
+            uri:                "${FORD_VEHICLE_API}/rcc/profile/status",
+            headers:            fordHeaders,
+            body:               JsonOutput.toJson([vin: vin]),
+            requestContentType: "application/json",
+            contentType:        "application/json",
+        ]) { resp ->
+            if (resp.status == 200) {
+                logDebug("sendRccCommand: profile/status raw response: ${resp.data}")
+                userPreferences = resp.data?.rccUserProfiles ?: []
+                logDebug("sendRccCommand: read ${userPreferences.size()} RCC preferences")
+            } else {
+                logError("sendRccCommand: profile/status HTTP ${resp.status}")
+            }
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("sendRccCommand: profile/status HTTP ${e.statusCode} — ${errBody ?: e.message}")
+        return false
+    } catch (Exception e) {
+        logError("sendRccCommand: profile/status ${e.message}")
+        return false
+    }
+
+    if (userPreferences.isEmpty()) {
+        // profile/status returned no preferences — vehicle uses "forced" RCC mode.
+        // Mirrors fordpass_bridge.py::req_remote_climate() _remote_climate_control_forced path:
+        // inject a safe default profile (all accessories off, 22°C target).
+        logInfo("sendRccCommand: profile/status returned empty rccUserProfiles — using defaults")
+        userPreferences = [
+            [preferenceType: "RccHeatedWindshield_Rq",    preferenceValue: "Off"],
+            [preferenceType: "RccRearDefrost_Rq",         preferenceValue: "Off"],
+            [preferenceType: "RccHeatedSteeringWheel_Rq", preferenceValue: "Off"],
+            [preferenceType: "RccLeftFrontClimateSeat_Rq",  preferenceValue: "Off"],
+            [preferenceType: "RccLeftRearClimateSeat_Rq",   preferenceValue: "Off"],
+            [preferenceType: "RccRightFrontClimateSeat_Rq", preferenceValue: "Off"],
+            [preferenceType: "RccRightRearClimateSeat_Rq",  preferenceValue: "Off"],
+            [preferenceType: "SetPointTemp_Rq",           preferenceValue: "22_0"],
+        ]
+    }
+
+    // Step 2: PUT update with crccStateFlag and current preferences
+    Map updateBody = [crccStateFlag: flag, userPreferences: userPreferences, vin: vin]
+    logDebug("sendRccCommand(${flag}): sending update body: ${JsonOutput.toJson(updateBody)}")
+    boolean success = false
+    try {
+        httpPut([
+            uri:                "${FORD_VEHICLE_API}/rcc/profile/update",
+            headers:            fordHeaders,
+            body:               JsonOutput.toJson(updateBody),
+            requestContentType: "application/json",
+            contentType:        "application/json",
+        ]) { resp ->
+            success = (resp.status >= 200 && resp.status < 300)
+            logDebug("sendRccCommand(${flag}): profile/update HTTP ${resp.status} — ${resp.data}")
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("sendRccCommand(${flag}): profile/update HTTP ${e.statusCode} — ${errBody ?: e.message}")
+    } catch (Exception e) {
+        logError("sendRccCommand(${flag}): profile/update ${e.message}")
     }
     return success
 }

--- a/apps/FordPassConnect.groovy
+++ b/apps/FordPassConnect.groovy
@@ -964,6 +964,7 @@ boolean sendVehicleCommand(String commandName, Map props = [:], String version =
     } catch (Exception e) {
         logError("sendVehicleCommand(${commandName}): ${e.message}")
     }
+
     return success
 }
 

--- a/apps/FordPassConnect.groovy
+++ b/apps/FordPassConnect.groovy
@@ -850,35 +850,37 @@ Map fetchVehicleList() {
 
 /**
  * Fetch full vehicle status / metrics for the given VIN.
- * Returns the raw parsed JSON Map, or null on failure.
+ * Returns the raw parsed JSON Map (with "metrics" at the root), or null on failure.
  *
- * Same endpoint, method, and auth as fetchVehicleList — both use
- * FORD_VEHICLE_API/expdashboard/v1/details/ with auth-token header.
+ * Uses the Autonomic telemetry API — NOT the Ford dashboard endpoint.
+ * The response structure is:
+ *   { "metrics": { ... }, "states": { ... }, "events": [...], ... }
+ *
+ * Auth: "Authorization: Bearer {autoToken}" (Autonomic token, NOT ford auth-token)
+ * Mirrors fordpass_bridge.py::req_status() (do_as_post=False path)
  */
 Map fetchVehicleStatus(String vin) {
     logDebug("fetchVehicleStatus(${vin})")
     if (!ensureValidTokens()) { return null }
 
-    Map regionCfg = REGIONS[state.region ?: "usa"]
-    Map headers   = API_HEADERS + [
-        "auth-token":     state.fordToken,
-        "Application-Id": regionCfg.app_id,
-        "countryCode":    regionCfg.countrycode,
-        "locale":         regionCfg.locale,
+    Map headers = [
+        "Accept-Encoding": "gzip",
+        "Connection":      "keep-alive",
+        "User-Agent":      "okhttp/4.12.0",
+        "Authorization":   "Bearer ${state.autoToken}",
     ]
-    String body = JsonOutput.toJson([dashboardRefreshRequest: "All"])
 
     Map result = null
     try {
-        httpPost([
-            uri:                "${FORD_VEHICLE_API}/expdashboard/v1/details/",
-            headers:            headers,
-            body:               body,
-            requestContentType: "application/json",
-            contentType:        "application/json",
+        httpGet([
+            uri:         "${AUTONOMIC_API_URL}/telemetry/sources/fordpass/vehicles/${vin}",
+            query:       ["lrdt": "01-01-1970 00:00:00"],
+            headers:     headers,
+            contentType: "application/json",
         ]) { resp ->
-            if (resp.status == 200 || resp.status == 207) {
+            if (resp.status == 200) {
                 result = resp.data as Map
+                logDebug("fetchVehicleStatus: HTTP 200 — metrics keys: ${(result?.metrics as Map)?.keySet()?.take(10)}")
             } else {
                 logError("fetchVehicleStatus: HTTP ${resp.status}")
             }

--- a/apps/FordPassConnect.groovy
+++ b/apps/FordPassConnect.groovy
@@ -53,6 +53,12 @@ definition(
 @Field String AUTONOMIC_API_URL      = "https://api.autonomic.ai/v1"
 @Field String AUTONOMIC_BETA_API_URL = "https://api.autonomic.ai/v1beta"
 
+// ABRP's public "Generic" telemetry API key — shared by DIY/generic telemetry
+// integrations that don't register their own app with Iternio. Paired with a
+// per-vehicle "Generic" token obtained from the ABRP app (Vehicle → Live Data → Generic).
+@Field String ABRP_API_KEY       = "32b2162f-9599-4647-8139-66e9f9528370"
+@Field String ABRP_TELEMETRY_URL = "https://api.iternio.com/1/tlm/send"
+
 // Default HTTP headers matching the FordPass Android app (okhttp/4.12.0)
 @Field Map DEFAULT_HEADERS = [
     "Accept-Encoding": "gzip",
@@ -232,6 +238,29 @@ def mainPage() {
                 defaultValue: "5",
                 required:     true
             )
+        }
+
+        section("ABRP (A Better Route Planner) Live Data") {
+            input(
+                name:           "abrpEnabled",
+                type:           "bool",
+                title:          "Push live telemetry to ABRP",
+                defaultValue:   false,
+                submitOnChange: true
+            )
+            if (settings.abrpEnabled) {
+                paragraph(
+                    "In the ABRP app: open your vehicle → <b>Live Data</b> → link it using the " +
+                    "<b>Generic</b> connection method, then paste the token it gives you below. " +
+                    "Telemetry is pushed to ABRP every time this app polls the vehicle (see Polling Interval above)."
+                )
+                input(
+                    name:     "abrpToken",
+                    type:     "text",
+                    title:    "ABRP Generic Token",
+                    required: true
+                )
+            }
         }
 
         section("Logging") {
@@ -780,6 +809,85 @@ void pollVehicle() {
         child.parseVehicleData(data)
     } else {
         logWarn("pollVehicle: child device not found for VIN ${state.vin}")
+    }
+
+    pushAbrpTelemetry(data)
+}
+
+// ---------------------------------------------------------------------------
+// ABRP (A Better Route Planner) live telemetry
+// ---------------------------------------------------------------------------
+
+/**
+ * Push live telemetry to ABRP after a successful poll.
+ *
+ * Reads directly from the raw Autonomic metrics (not the driver's converted,
+ * unit-scaled attributes) so ABRP always gets km/h, %, and Celsius regardless
+ * of the driver's distance/temperature preferences.
+ *
+ * Mirrors the request shape used by Iternio's own reference client
+ * (github.com/iternio/autopi-link): a GET to /1/tlm/send with api_key, token,
+ * and a compact JSON "tlm" object all in the query string.
+ */
+void pushAbrpTelemetry(Map rawData) {
+    if (!settings.abrpEnabled) return
+    if (!settings.abrpToken) {
+        logWarn("pushAbrpTelemetry: ABRP push enabled but no token configured — skipping")
+        return
+    }
+
+    Map metrics = rawData?.metrics ?: [:]
+    Map tlm = [utc: (long)(new Date().time / 1000)]
+
+    def soc = metrics.xevBatteryStateOfCharge?.value
+    if (soc != null) tlm.soc = soc as BigDecimal
+
+    def speed = metrics.vehicleSpeed?.value
+    if (speed != null) tlm.speed = speed as BigDecimal
+
+    def loc = metrics.position?.value?.location
+    def lat = loc?.lat ?: loc?.latitude
+    def lon = loc?.lon ?: loc?.longitude
+    if (lat != null && lon != null) {
+        tlm.lat = lat as BigDecimal
+        tlm.lon = lon as BigDecimal
+    }
+
+    // Ford API returns 0 for "no sensor reading" as well as a genuine 0°C — same
+    // convention the driver uses for ambientTemp, so treat 0 as "unavailable" here too.
+    def extTemp = metrics.ambientTemp?.value
+    if (extTemp != null && (extTemp as BigDecimal) != 0) tlm.ext_temp = extTemp as BigDecimal
+
+    String chargeStatus = metrics.xevBatteryChargeDisplayStatus?.value?.toString()
+    if (chargeStatus != null) tlm.is_charging = (chargeStatus == "IN_PROGRESS") ? 1 : 0
+
+    String ignition = metrics.ignitionStatus?.value?.toString()?.toUpperCase()
+    if (ignition != null) tlm.is_parked = (ignition in ["START", "RUN"]) ? 0 : 1
+
+    if (tlm.soc == null && tlm.lat == null) {
+        logDebug("pushAbrpTelemetry: no usable telemetry fields in this poll — skipping")
+        return
+    }
+
+    String tlmJson = JsonOutput.toJson(tlm)
+    String url = "${ABRP_TELEMETRY_URL}?api_key=${java.net.URLEncoder.encode(ABRP_API_KEY, 'UTF-8')}" +
+                 "&token=${java.net.URLEncoder.encode(settings.abrpToken as String, 'UTF-8')}" +
+                 "&tlm=${java.net.URLEncoder.encode(tlmJson, 'UTF-8')}"
+
+    try {
+        httpGet([uri: url]) { resp ->
+            if (resp.status == 200) {
+                logDebug("pushAbrpTelemetry: OK — ${tlmJson}")
+            } else {
+                logWarn("pushAbrpTelemetry: HTTP ${resp.status} — ${resp.data}")
+            }
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("pushAbrpTelemetry: HTTP ${e.statusCode} — ${errBody ?: e.message}")
+    } catch (Exception e) {
+        logError("pushAbrpTelemetry: ${e.message}")
     }
 }
 

--- a/apps/FordPassConnect.groovy
+++ b/apps/FordPassConnect.groovy
@@ -1,0 +1,1108 @@
+/**
+ * FordPass Connect — Hubitat App
+ *
+ * Ported from marq24/ha-fordpass (Home Assistant custom integration).
+ * Source: https://github.com/marq24/ha-fordpass
+ *
+ * Implements the multi-step OAuth2 PKCE flow used by the FordPass mobile app,
+ * exchanges tokens with both the Ford Foundational API and the Autonomic API,
+ * and creates/updates child FordPass Vehicle devices.
+ *
+ * Setup flow:
+ *   1. mainPage      — status overview, entry point
+ *   2. regionPage    — pick brand (Ford/Lincoln) + region
+ *   3. authPage      — generate PKCE pair, show Ford login URL, accept redirect URL paste
+ *   4. vinPage       — list vehicles on the account, pick one, create child device
+ *
+ * Token management:
+ *   - Ford Foundational token  stored in state.fordToken / state.fordRefreshToken / state.fordTokenExpiry
+ *   - Autonomic token          stored in state.autoToken / state.autoTokenExpiry
+ *   - Tokens are refreshed automatically before every API call
+ *   - A scheduled job (refreshTokens) runs every 4 minutes as a safety net
+ */
+
+import groovy.transform.Field
+import java.security.MessageDigest
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+// definition() must come immediately after imports — before any @Field declarations —
+// so Hubitat's app pre-processor can inject it into scope correctly.
+definition(
+    name:        "FordPass Connect",
+    namespace:   "fordpass-hubitat",
+    author:      "Ported from marq24/ha-fordpass",
+    description: "Connect Ford and Lincoln vehicles via the FordPass / Autonomic API",
+    category:    "Convenience",
+    iconUrl:     "",
+    iconX2Url:   "",
+    singleInstance: false
+)
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+@Field String OAUTH_ID  = "4566605f-43a7-400a-946e-89cc9fdb0bd7"
+@Field String CLIENT_ID = "09852200-05fd-41f6-8c21-d36d3497dc64"
+
+@Field String FORD_FOUNDATIONAL_API = "https://api.foundational.ford.com/api"
+@Field String FORD_VEHICLE_API      = "https://api.vehicle.ford.com/api"
+@Field String FORD_MPS_API          = "https://api.mps.ford.com/api"
+@Field String AUTONOMIC_ACCOUNT_URL = "https://accounts.autonomic.ai/v1"
+@Field String AUTONOMIC_API_URL     = "https://api.autonomic.ai/v1"
+
+// Default HTTP headers matching the FordPass Android app (okhttp/4.12.0)
+@Field Map DEFAULT_HEADERS = [
+    "Accept-Encoding": "gzip",
+    "Connection":      "keep-alive",
+    "User-Agent":      "okhttp/4.12.0",
+]
+@Field Map API_HEADERS    = ["Accept-Encoding": "gzip", "Connection": "keep-alive", "User-Agent": "okhttp/4.12.0", "Content-Type": "application/json"]
+@Field Map LOGIN_HEADERS  = ["Accept-Encoding": "gzip", "Connection": "keep-alive", "User-Agent": "okhttp/4.12.0", "Content-Type": "application/x-www-form-urlencoded"]
+
+/**
+ * Region definitions.
+ * Keys: app_id, locale, login_url, countrycode
+ * Optional keys: sign_up_addon (Lincoln), redirect_schema (default "fordapp")
+ *
+ * Only actively confirmed regions are listed here. Add more from const.py as needed.
+ */
+@Field Map REGIONS = [
+    "usa": [
+        app_id:      "BFE8C5ED-D687-4C19-A5DD-F92CDFC4503A",
+        locale:      "en-US",
+        login_url:   "https://login.ford.com",
+        countrycode: "USA"
+    ],
+    "can": [
+        app_id:      "BFE8C5ED-D687-4C19-A5DD-F92CDFC4503A",
+        locale:      "en-CA",
+        login_url:   "https://login.ford.com",
+        countrycode: "CAN"
+    ],
+    "mex": [
+        app_id:      "BFE8C5ED-D687-4C19-A5DD-F92CDFC4503A",
+        locale:      "es-MX",
+        login_url:   "https://login.ford.com",
+        countrycode: "MEX"
+    ],
+    "gbr": [
+        app_id:      "667D773E-1BDC-4139-8AD0-2B16474E8DC7",
+        locale:      "en-GB",
+        login_url:   "https://login.ford.co.uk",
+        countrycode: "GBR"
+    ],
+    "deu": [
+        app_id:      "667D773E-1BDC-4139-8AD0-2B16474E8DC7",
+        locale:      "de-DE",
+        login_url:   "https://login.ford.de",
+        countrycode: "DEU"
+    ],
+    "fra": [
+        app_id:      "667D773E-1BDC-4139-8AD0-2B16474E8DC7",
+        locale:      "fr-FR",
+        login_url:   "https://login.ford.com",
+        countrycode: "FRA"
+    ],
+    "nld": [
+        app_id:      "667D773E-1BDC-4139-8AD0-2B16474E8DC7",
+        locale:      "nl-NL",
+        login_url:   "https://login.ford.com",
+        countrycode: "NLD"
+    ],
+    "ita": [
+        app_id:      "667D773E-1BDC-4139-8AD0-2B16474E8DC7",
+        locale:      "it-IT",
+        login_url:   "https://login.ford.com",
+        countrycode: "ITA"
+    ],
+    "esp": [
+        app_id:      "667D773E-1BDC-4139-8AD0-2B16474E8DC7",
+        locale:      "es-ES",
+        login_url:   "https://login.ford.com",
+        countrycode: "ESP"
+    ],
+    "nor": [
+        app_id:      "667D773E-1BDC-4139-8AD0-2B16474E8DC7",
+        locale:      "no-NB",
+        login_url:   "https://login.ford.no",
+        countrycode: "NOR"
+    ],
+    "aus": [
+        app_id:      "39CD6590-B1B9-42CB-BEF9-0DC1FDB96260",
+        locale:      "en-AU",
+        login_url:   "https://login.ford.com",
+        countrycode: "AUS"
+    ],
+    "nzl": [
+        app_id:      "39CD6590-B1B9-42CB-BEF9-0DC1FDB96260",
+        locale:      "en-NZ",
+        login_url:   "https://login.ford.com",
+        countrycode: "NZL"
+    ],
+    "zaf": [
+        app_id:      "71AA9ED7-B26B-4C15-835E-9F35CC238561",
+        locale:      "en-ZA",
+        login_url:   "https://login.ford.com",
+        countrycode: "ZAF"
+    ],
+    "rest_of_europe": [
+        app_id:      "667D773E-1BDC-4139-8AD0-2B16474E8DC7",
+        locale:      "en-GB",
+        login_url:   "https://login.ford.com",
+        countrycode: "GBR"
+    ],
+    "lincoln_usa": [
+        app_id:         "45133B88-0671-4AAF-B8D1-99E684ED4E45",
+        locale:         "en-US",
+        login_url:      "https://login.lincoln.com",
+        countrycode:    "USA",
+        sign_up_addon:  "Lincoln_",
+        redirect_schema:"lincolnapp"
+    ],
+]
+
+// ---------------------------------------------------------------------------
+// Preferences (app pages)
+// ---------------------------------------------------------------------------
+
+preferences {
+    page(name: "mainPage")
+    page(name: "regionPage")
+    page(name: "authPage")
+    page(name: "tokenPage")
+    page(name: "vinPage")
+}
+
+// ---------------------------------------------------------------------------
+// Page definitions
+// ---------------------------------------------------------------------------
+
+def mainPage() {
+    dynamicPage(name: "mainPage", title: "FordPass Connect", install: true, uninstall: true) {
+
+        boolean isConfigured = (state.fordToken != null && state.vin != null)
+
+        section("Status") {
+            if (isConfigured) {
+                paragraph "Connected  |  VIN: ${state.vin}  |  Region: ${state.region}"
+                paragraph "Last token refresh: ${state.lastTokenRefresh ?: 'Never'}"
+            } else {
+                paragraph "Not yet configured. Use the button below to set up your vehicle."
+            }
+        }
+
+        section("Setup") {
+            href(
+                name:        "toRegionPage",
+                title:       isConfigured ? "Re-authenticate / Change Region" : "Connect a Vehicle",
+                description: "Step 1 of 3 — Select brand and region",
+                page:        "regionPage"
+            )
+        }
+
+        if (isConfigured) {
+            section("Actions") {
+                input(
+                    name:         "pollNow",
+                    type:         "button",
+                    title:        "Poll Vehicle Now",
+                    submitOnChange: true
+                )
+                input(
+                    name:         "clearTokens",
+                    type:         "button",
+                    title:        "Clear Saved Tokens",
+                    submitOnChange: true
+                )
+            }
+            section("Child Devices") {
+                paragraph "Vehicle device: FordPass Vehicle — ${state.vin}"
+            }
+        }
+
+        section("Polling Interval") {
+            input(
+                name:         "pollIntervalMinutes",
+                type:         "enum",
+                title:        "Auto-refresh every",
+                options:      ["5": "5 min", "10": "10 min", "15": "15 min", "30": "30 min", "0": "Disabled"],
+                defaultValue: "5",
+                required:     true
+            )
+        }
+
+        section("Logging") {
+            input(name: "enableDebugLog", type: "bool", title: "Enable debug logging", defaultValue: false)
+        }
+    }
+}
+
+def regionPage() {
+    // Clear PKCE state and stale auth settings so authPage always generates a fresh pair.
+    // settings.loginUrlDisplay persists the old authorize URL across sessions — if not cleared,
+    // the user copies the old URL (old challenge) while state.codeVerifier holds a new verifier.
+    state.remove("codeVerifier")
+    state.remove("pkceChallenge")
+    app.updateSetting("loginUrlDisplay", [value: "", type: "text"])
+    app.updateSetting("redirectUrl",     [value: "", type: "text"])
+
+    dynamicPage(name: "regionPage", title: "Step 1 — Brand & Region", nextPage: "authPage", uninstall: false) {
+        section("Brand") {
+            input(
+                name:         "brand",
+                type:         "enum",
+                title:        "Brand",
+                options:      ["ford": "Ford", "lincoln": "Lincoln"],
+                defaultValue: "ford",
+                required:     true,
+                submitOnChange: true
+            )
+        }
+
+        List regionOptions
+        if (settings.brand == "lincoln") {
+            regionOptions = [["lincoln_usa": "Lincoln USA"]]
+        } else {
+            regionOptions = [
+                ["usa":            "United States"],
+                ["can":            "Canada"],
+                ["mex":            "Mexico"],
+                ["gbr":            "United Kingdom"],
+                ["deu":            "Germany"],
+                ["fra":            "France"],
+                ["nld":            "Netherlands"],
+                ["ita":            "Italy"],
+                ["esp":            "Spain"],
+                ["nor":            "Norway"],
+                ["aus":            "Australia"],
+                ["nzl":            "New Zealand"],
+                ["zaf":            "South Africa"],
+                ["rest_of_europe": "Other European Countries"],
+            ]
+        }
+
+        section("Region") {
+            input(
+                name:         "region",
+                type:         "enum",
+                title:        "Region",
+                options:      regionOptions,
+                defaultValue: "usa",
+                required:     true
+            )
+        }
+
+        section("Account") {
+            input(name: "username", type: "email", title: "FordPass / Lincoln Way email", required: true)
+        }
+
+        section("Info") {
+            paragraph(
+                "On the next page you will get a link to the Ford/Lincoln login page. " +
+                "After logging in, your browser will be redirected to a URL starting with " +
+                "<b>fordapp://</b> (or <b>lincolnapp://</b>). " +
+                "Copy the full redirect URL and paste it back into the next page."
+            )
+        }
+    }
+}
+
+def authPage() {
+    // Generate the PKCE pair ONCE per auth flow and persist both halves.
+    // authPage() is called again when the user returns to paste the redirect URL —
+    // regenerating here would overwrite state.codeVerifier and break PKCE verification.
+    if (!state.codeVerifier || !state.pkceChallenge) {
+        Map pkce = generatePkcePair()
+        state.codeVerifier  = pkce.verifier
+        state.pkceChallenge = pkce.challenge
+        logDebug("authPage: generated new PKCE pair")
+    } else {
+        logDebug("authPage: reusing existing PKCE pair")
+    }
+
+    String regionKey = settings.region ?: "usa"
+    Map regionCfg    = REGIONS[regionKey]
+    String loginUrl  = regionCfg?.login_url  ?: "https://login.ford.com"
+    String locale    = regionCfg?.locale     ?: "en-US"
+    String appId     = regionCfg?.app_id     ?: ""
+    String schema    = regionCfg?.redirect_schema ?: "fordapp"
+    String addon     = regionCfg?.sign_up_addon   ?: ""
+    String policy    = "B2C_1A_SignInSignUp_${addon}${locale}"
+    String countryCode = regionCfg?.countrycode ?: "USA"
+
+    String authorizeUrl = ""
+    try {
+        authorizeUrl = buildAuthorizeUrl(loginUrl, policy, CLIENT_ID, schema,
+                                        state.pkceChallenge as String,
+                                        appId, locale, countryCode)
+    } catch (Exception e) {
+        logError("authPage: could not build login URL: ${e.message}")
+    }
+
+    dynamicPage(name: "authPage", title: "Step 2 — Authorize FordPass", nextPage: "vinPage", uninstall: false) {
+        section("Step 1 — Open the Ford login page in your browser") {
+            paragraph(
+                "<b>Copy the URL below</b> and open it in Safari or Chrome. " +
+                "Do NOT use Hubitat's built-in browser — Ford's login page blocks embedded browsers."
+            )
+            // Use paragraph (not input) so this always reflects the freshly generated PKCE challenge.
+            // An input() would cache its value in settings and show a stale URL on subsequent visits.
+            paragraph("<b>Ford Login URL:</b><br><small>${authorizeUrl}</small>")
+            paragraph "Region: ${regionKey}  |  Policy: ${policy}  |  App-Id: ${appId}"
+        }
+        section("Step 2 — Paste the redirect URL") {
+            paragraph(
+                "After logging in, your browser will try to open a URL starting with <b>${schema}://</b>. " +
+                "The page will fail to load — that is expected. " +
+                "Copy the full URL from your browser's address bar and paste it here."
+            )
+            input(name: "redirectUrl", type: "text", title: "Paste the full redirect URL here", required: true)
+        }
+    }
+}
+
+def vinPage() {
+    // Exchange the authorization code for tokens, then list available VINs.
+    String errorMsg = null
+    Map vinOptions = [:]
+
+    if (settings.redirectUrl && state.codeVerifier) {
+        try {
+            boolean ok = exchangeAuthCodeForTokens(settings.redirectUrl, state.codeVerifier, settings.region)
+            if (ok) {
+                vinOptions = fetchVehicleList()
+            } else {
+                errorMsg = "Token exchange failed. Check logs and try again from Step 1."
+            }
+        } catch (Exception e) {
+            logError("vinPage: exception during token exchange: ${e.message}")
+            errorMsg = "Exception during token exchange: ${e.message}"
+        }
+    } else {
+        errorMsg = "No redirect URL captured. Go back and complete Step 2."
+    }
+
+    dynamicPage(name: "vinPage", title: "Step 3 — Select Vehicle", install: true, uninstall: false) {
+        if (errorMsg) {
+            section("Error") { paragraph "<b style='color:red'>${errorMsg}</b>" }
+        } else if (vinOptions.isEmpty()) {
+            section("No vehicles found") {
+                paragraph "No vehicles were returned by the API. Make sure your account has at least one connected vehicle."
+            }
+        } else {
+            section("Select your vehicle") {
+                input(
+                    name:     "selectedVin",
+                    type:     "enum",
+                    title:    "Vehicle",
+                    options:  vinOptions,
+                    required: true
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+def installed() {
+    logDebug("installed()")
+    initialize()
+}
+
+def updated() {
+    logDebug("updated()")
+    unschedule()
+    initialize()
+
+    if (settings.pollNow) {
+        pollVehicle()
+        app.updateSetting("pollNow", false)
+    }
+    if (settings.clearTokens) {
+        clearAllTokens()
+        app.updateSetting("clearTokens", false)
+    }
+}
+
+def initialize() {
+    if (settings.selectedVin) {
+        state.vin = settings.selectedVin
+        state.region = settings.region
+        ensureChildDevice(state.vin)
+    }
+
+    scheduleTokenRefresh()
+    schedulePolling()
+}
+
+def appButtonHandler(String buttonName) {
+    switch (buttonName) {
+        case "pollNow":
+            pollVehicle()
+            break
+        case "clearTokens":
+            clearAllTokens()
+            break
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PKCE helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a PKCE code_verifier (128 URL-safe chars) and code_challenge (S256).
+ * Mirrors config_flow.py::generate_code_challenge().
+ */
+Map generatePkcePair() {
+    // SecureRandom is blocked in Hubitat's sandbox. UUID.randomUUID() is backed
+    // by a SecureRandom internally (via java.util.UUID) and is available here.
+    // Four UUIDs give 128 hex chars (512 bits of entropy) — well above the PKCE minimum.
+    String verifier = (1..4).collect { UUID.randomUUID().toString().replace("-", "") }.join("")
+
+    MessageDigest digest = MessageDigest.getInstance("SHA-256")
+    byte[] hashBytes = digest.digest(verifier.getBytes("UTF-8"))
+
+    String challenge = hashBytes.encodeBase64().toString()
+        .tr('+/', '-_')
+        .replaceAll('=+$', '')
+
+    return [verifier: verifier, challenge: challenge]
+}
+
+/**
+ * Build the Ford OAuth2 authorize URL with PKCE parameters.
+ * Equivalent to the URL the HA config flow shows to the user.
+ */
+/**
+ * Build the Ford OAuth2 authorize URL with PKCE parameters.
+ *
+ * Matches generate_url() in config_flow.py exactly — parameter names, order,
+ * and encoding must match what Ford's B2C tenant expects.
+ *
+ * Key points vs a generic OAuth2 URL:
+ *  - redirect_uri is NOT percent-encoded (Ford's server expects the raw ://)
+ *  - scope has a LEADING %20 space: "%20{clientId}%20openid"
+ *  - ford_application_id and country_code are required Ford-specific params
+ *  - max_age, ui_locales, language_code are also required
+ */
+String buildAuthorizeUrl(String loginUrl, String policy, String clientId,
+                         String schema, String codeChallenge,
+                         String appId, String locale, String countryCode) {
+    // redirect_uri intentionally left un-encoded — matches Python source
+    String redirectUri = "${schema}://userauthorized"
+
+    return "${loginUrl}/${OAUTH_ID}/${policy}/oauth2/v2.0/authorize" +
+        "?redirect_uri=${redirectUri}" +
+        "&response_type=code" +
+        "&max_age=3600" +
+        "&code_challenge=${codeChallenge}" +
+        "&code_challenge_method=S256" +
+        "&scope=%20${clientId}%20openid" +   // leading %20 matches Python source
+        "&client_id=${clientId}" +
+        "&ui_locales=${locale}" +
+        "&language_code=${locale}" +
+        "&ford_application_id=${appId}" +
+        "&country_code=${countryCode}"
+}
+
+// ---------------------------------------------------------------------------
+// OAuth token exchange (mirrors fordpass_bridge.py::generate_tokens())
+// ---------------------------------------------------------------------------
+
+/**
+ * Full token exchange pipeline:
+ *   Step 1 — POST to the regional B2C token endpoint with the authorization code
+ *   Step 2 — POST to Ford Foundational API (cat-with-b2c-access-token)
+ *   Step 3 — Exchange Foundational token for Autonomic token
+ *
+ * Returns true on success, false on failure.
+ * Stores tokens in state on success.
+ */
+boolean exchangeAuthCodeForTokens(String redirectUrl, String codeVerifier, String regionKey) {
+    logDebug("exchangeAuthCodeForTokens()")
+
+    // Extract authorization code from the redirect URL
+    String code = extractQueryParam(redirectUrl, "code")
+    if (!code) {
+        logError("exchangeAuthCodeForTokens: no 'code' param in redirect URL: ${redirectUrl}")
+        return false
+    }
+    logDebug("exchangeAuthCodeForTokens: extracted code (length ${code.length()})")
+
+    Map regionCfg   = REGIONS[regionKey]
+    String loginUrl = regionCfg.login_url
+    String locale   = regionCfg.locale
+    String addon    = regionCfg.sign_up_addon ?: ""
+    String schema   = regionCfg.redirect_schema ?: "fordapp"
+    String policy   = "B2C_1A_SignInSignUp_${addon}${locale}"
+
+    // --- Step 1: B2C token endpoint ---
+    String tokenEndpoint = "${loginUrl}/${OAUTH_ID}/${policy}/oauth2/v2.0/token"
+    String b2cBody = [
+        "client_id":     CLIENT_ID,
+        "scope":         "${CLIENT_ID} openid",
+        "redirect_uri":  "${schema}://userauthorized",
+        "grant_type":    "authorization_code",
+        "resource":      "",
+        "code":          code,
+        "code_verifier": codeVerifier,
+    ].collect { k, v -> "${k}=${java.net.URLEncoder.encode(v as String, 'UTF-8')}" }.join("&")
+
+    logDebug("exchangeAuthCodeForTokens: Step 1 — POST to ${tokenEndpoint}")
+    Map b2cResponse = httpPostSync(tokenEndpoint, b2cBody, LOGIN_HEADERS)
+
+    if (!b2cResponse || !b2cResponse.access_token) {
+        logError("exchangeAuthCodeForTokens: Step 1 FAILED — response: ${b2cResponse}")
+        return false
+    }
+    logDebug("exchangeAuthCodeForTokens: Step 1 OK — got B2C access_token")
+
+    // --- Step 2: Ford Foundational API (cat-with-b2c-access-token) ---
+    boolean step2ok = exchangeB2CTokenForFordToken(b2cResponse.access_token, regionCfg.app_id)
+    if (!step2ok) { return false }
+
+    // --- Step 3: Autonomic token (uses the Ford Foundational access_token) ---
+    boolean step3ok = refreshAutoToken()
+    if (!step3ok) {
+        // Non-fatal: some commands only need the Ford token; log and continue
+        logWarn("exchangeAuthCodeForTokens: Step 3 (Autonomic) FAILED — vehicle commands may not work")
+    }
+
+    state.lastTokenRefresh = new Date().toString()
+    logInfo("exchangeAuthCodeForTokens: all tokens acquired successfully")
+    return true
+}
+
+/**
+ * Step 2: Exchange the B2C access_token for a Ford Foundational API token.
+ * Mirrors fordpass_bridge.py::generate_tokens_part2()
+ */
+boolean exchangeB2CTokenForFordToken(String b2cAccessToken, String appId) {
+    logDebug("exchangeB2CTokenForFordToken()")
+    String url  = "${FORD_FOUNDATIONAL_API}/token/v2/cat-with-b2c-access-token"
+    Map headers = API_HEADERS + ["Application-Id": appId]
+    String body = JsonOutput.toJson([idpToken: b2cAccessToken])
+
+    Map resp = httpPostSync(url, body, headers)
+    if (!resp || !resp.access_token) {
+        logError("exchangeB2CTokenForFordToken: FAILED — response: ${resp}")
+        return false
+    }
+
+    storeFoundationalToken(resp)
+    logDebug("exchangeB2CTokenForFordToken: OK")
+    return true
+}
+
+/**
+ * Refresh the Ford Foundational token using the stored refresh_token.
+ * Mirrors fordpass_bridge.py::_request_token()
+ */
+boolean refreshFoundationalToken() {
+    logDebug("refreshFoundationalToken()")
+    if (!state.fordRefreshToken) {
+        logError("refreshFoundationalToken: no refresh token stored — re-authentication required")
+        return false
+    }
+
+    Map regionCfg = REGIONS[state.region ?: "usa"]
+    String url    = "${FORD_FOUNDATIONAL_API}/token/v2/cat-with-refresh-token"
+    Map headers   = API_HEADERS + ["Application-Id": regionCfg.app_id]
+    String body   = JsonOutput.toJson([refresh_token: state.fordRefreshToken])
+
+    Map resp = httpPostSync(url, body, headers)
+    if (!resp || !resp.access_token) {
+        logError("refreshFoundationalToken: FAILED — response: ${resp}")
+        return false
+    }
+
+    storeFoundationalToken(resp)
+    logDebug("refreshFoundationalToken: OK")
+    return true
+}
+
+/**
+ * Exchange the Ford Foundational access_token for an Autonomic API token.
+ * Mirrors fordpass_bridge.py::_request_auto_token()
+ *
+ * The Autonomic token is used for vehicle commands (lock/unlock, remote start, etc.)
+ */
+boolean refreshAutoToken() {
+    logDebug("refreshAutoToken()")
+    if (!state.fordToken) {
+        logError("refreshAutoToken: no Ford token available — cannot get Autonomic token")
+        return false
+    }
+
+    String url  = "${AUTONOMIC_ACCOUNT_URL}/auth/oidc/token"
+    Map headers = [
+        "accept":       "*/*",
+        "content-type": "application/x-www-form-urlencoded",
+    ]
+    String body = [
+        "subject_token":      state.fordToken,
+        "subject_issuer":     "fordpass",
+        "client_id":          "fordpass-prod",
+        "grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    ].collect { k, v -> "${k}=${java.net.URLEncoder.encode(v as String, 'UTF-8')}" }.join("&")
+
+    Map resp = httpPostSync(url, body, headers)
+    if (!resp || !resp.access_token) {
+        logError("refreshAutoToken: FAILED — response: ${resp}")
+        return false
+    }
+
+    long now = (long)(new Date().time / 1000)
+    state.autoToken       = resp.access_token
+    state.autoTokenExpiry = now + (resp.expires_in as long ?: 290L)
+
+    logDebug("refreshAutoToken: OK — expires in ${resp.expires_in}s")
+    return true
+}
+
+// ---------------------------------------------------------------------------
+// Token storage helpers
+// ---------------------------------------------------------------------------
+
+private void storeFoundationalToken(Map tokenResp) {
+    long now = (long)(new Date().time / 1000)
+    state.fordToken         = tokenResp.access_token
+    state.fordRefreshToken  = tokenResp.refresh_token
+    state.fordTokenExpiry   = now + (tokenResp.expires_in as long ?: 290L)
+    if (tokenResp.refresh_expires_in) {
+        state.fordRefreshTokenExpiry = now + (tokenResp.refresh_expires_in as long)
+    }
+}
+
+/**
+ * Ensure both tokens are valid before making an API call.
+ * Refreshes the Foundational token if it is expired (or within 30 s of expiry).
+ * Refreshes the Autonomic token if it is missing or expired.
+ *
+ * Call this at the top of every method that makes an API request.
+ * Returns false if tokens could not be refreshed (caller should abort).
+ */
+boolean ensureValidTokens() {
+    long now = (long)(new Date().time / 1000)
+
+    // Refresh Foundational token if expired (or close to it)
+    if (!state.fordToken || !state.fordTokenExpiry || now >= (state.fordTokenExpiry as long) - 30) {
+        logDebug("ensureValidTokens: Ford token expired or missing — refreshing")
+        if (!refreshFoundationalToken()) { return false }
+    }
+
+    // Refresh Autonomic token if missing or expired
+    if (!state.autoToken || !state.autoTokenExpiry || now >= (state.autoTokenExpiry as long) - 30) {
+        logDebug("ensureValidTokens: Autonomic token expired or missing — refreshing")
+        if (!refreshAutoToken()) {
+            // Non-fatal — Ford data reads don't need the Autonomic token
+            logWarn("ensureValidTokens: could not refresh Autonomic token")
+        }
+    }
+
+    return true
+}
+
+void clearAllTokens() {
+    logInfo("clearAllTokens(): clearing all stored tokens")
+    state.remove("fordToken")
+    state.remove("fordRefreshToken")
+    state.remove("fordTokenExpiry")
+    state.remove("fordRefreshTokenExpiry")
+    state.remove("autoToken")
+    state.remove("autoTokenExpiry")
+    state.remove("codeVerifier")
+    state.remove("lastTokenRefresh")
+}
+
+// ---------------------------------------------------------------------------
+// Scheduled token refresh
+// ---------------------------------------------------------------------------
+
+void scheduleTokenRefresh() {
+    // Refresh Ford token every 4 minutes as a safety net
+    // (tokens expire after ~5 min; we refresh 30 s before expiry per ensureValidTokens,
+    //  but this catches the case where Hubitat is idle)
+    schedule("0 */4 * * * ?", "tokenRefreshJob")
+}
+
+void tokenRefreshJob() {
+    logDebug("tokenRefreshJob()")
+    if (state.fordRefreshToken) {
+        refreshFoundationalToken()
+        refreshAutoToken()
+        state.lastTokenRefresh = new Date().toString()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vehicle data polling
+// ---------------------------------------------------------------------------
+
+void schedulePolling() {
+    String interval = settings.pollIntervalMinutes ?: "5"
+    if (interval == "0") {
+        logInfo("schedulePolling: polling disabled")
+        return
+    }
+    schedule("0 */${interval} * * * ?", "pollVehicle")
+    logInfo("schedulePolling: polling every ${interval} minutes")
+}
+
+void pollVehicle() {
+    logDebug("pollVehicle()")
+    if (!state.vin) {
+        logWarn("pollVehicle: no VIN configured")
+        return
+    }
+
+    if (!ensureValidTokens()) {
+        logError("pollVehicle: could not refresh tokens — aborting poll")
+        return
+    }
+
+    Map data = fetchVehicleStatus(state.vin)
+    if (data == null) {
+        logError("pollVehicle: fetchVehicleStatus returned null")
+        return
+    }
+
+    def child = getChildDevice(childDeviceId(state.vin))
+    if (child) {
+        child.parseVehicleData(data)
+    } else {
+        logWarn("pollVehicle: child device not found for VIN ${state.vin}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ford Foundational API calls
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the vehicle list for the authenticated account.
+ * Returns a Map of [vin: "Year Make Model (VIN)"] for use in a Hubitat enum input.
+ *
+ * Hubitat enum inputs require options as Map<value, displayLabel>.
+ * A List<[value:, name:]> is NOT recognised — the literal key "value" ends up as the setting.
+ *
+ * Mirrors fordpass_bridge.py::req_vehicles()
+ *  - Uses FORD_VEHICLE_API (api.vehicle.ford.com), NOT FORD_FOUNDATIONAL_API
+ *  - Is a POST with body {"dashboardRefreshRequest": "All"}
+ *  - Uses "auth-token" header, NOT "Authorization: Bearer"
+ *  - Accepts both 200 and 207 as success
+ */
+Map fetchVehicleList() {
+    logDebug("fetchVehicleList()")
+    if (!ensureValidTokens()) { return [:] }
+
+    Map regionCfg = REGIONS[state.region ?: settings.region ?: "usa"]
+    Map headers   = API_HEADERS + [
+        "auth-token":     state.fordToken,
+        "Application-Id": regionCfg.app_id,
+        "countryCode":    regionCfg.countrycode,
+        "locale":         regionCfg.locale,
+    ]
+    String body = JsonOutput.toJson([dashboardRefreshRequest: "All"])
+
+    Map vinOptions = [:]
+    try {
+        httpPost([
+            uri:                "${FORD_VEHICLE_API}/expdashboard/v1/details/",
+            headers:            headers,
+            body:               body,
+            requestContentType: "application/json",
+            contentType:        "application/json",
+        ]) { resp ->
+            if (resp.status == 200 || resp.status == 207) {
+                def data = resp.data
+                def vehicles = data?.userVehicles?.vehicleDetails ?: []
+                vehicles.each { v ->
+                    String vin   = v.VIN ?: v.vin ?: ""
+                    String year  = v.modelYear ?: ""
+                    String make  = v.make      ?: "Ford"
+                    String model = v.modelName ?: ""
+                    String label = "${year} ${make} ${model} (${vin})".trim()
+                    if (vin) { vinOptions[vin] = label }
+                }
+                logDebug("fetchVehicleList: HTTP ${resp.status} — found ${vinOptions.size()} vehicle(s)")
+            } else {
+                logError("fetchVehicleList: unexpected HTTP ${resp.status}")
+            }
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("fetchVehicleList: HTTP ${e.statusCode} — ${errBody ?: e.message}")
+    } catch (Exception e) {
+        logError("fetchVehicleList: ${e.message}")
+    }
+
+    return vinOptions
+}
+
+/**
+ * Fetch full vehicle status / metrics for the given VIN.
+ * Returns the raw parsed JSON Map, or null on failure.
+ *
+ * Same endpoint, method, and auth as fetchVehicleList — both use
+ * FORD_VEHICLE_API/expdashboard/v1/details/ with auth-token header.
+ */
+Map fetchVehicleStatus(String vin) {
+    logDebug("fetchVehicleStatus(${vin})")
+    if (!ensureValidTokens()) { return null }
+
+    Map regionCfg = REGIONS[state.region ?: "usa"]
+    Map headers   = API_HEADERS + [
+        "auth-token":     state.fordToken,
+        "Application-Id": regionCfg.app_id,
+        "countryCode":    regionCfg.countrycode,
+        "locale":         regionCfg.locale,
+    ]
+    String body = JsonOutput.toJson([dashboardRefreshRequest: "All"])
+
+    Map result = null
+    try {
+        httpPost([
+            uri:                "${FORD_VEHICLE_API}/expdashboard/v1/details/",
+            headers:            headers,
+            body:               body,
+            requestContentType: "application/json",
+            contentType:        "application/json",
+        ]) { resp ->
+            if (resp.status == 200 || resp.status == 207) {
+                result = resp.data as Map
+            } else {
+                logError("fetchVehicleStatus: HTTP ${resp.status}")
+            }
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("fetchVehicleStatus: HTTP ${e.statusCode} — ${errBody ?: e.message}")
+    } catch (Exception e) {
+        logError("fetchVehicleStatus: ${e.message}")
+    }
+    return result
+}
+
+// ---------------------------------------------------------------------------
+// Autonomic vehicle commands (used by the child driver via parent reference)
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a command to the vehicle via the Autonomic API.
+ *
+ * The command name goes in the JSON body as "type" — NOT in the URL path.
+ * URL: POST /v1/command/vehicles/{vin}/commands
+ * Body: { "type": commandName, "properties": {extra}, "tags": {}, "wakeUp": true }
+ *
+ * Mirrors fordpass_bridge.py::__request_and_poll_command_autonomic()
+ *
+ * commandName: "lock", "unlock", "remoteStart", "cancelRemoteStart",
+ *              "statusRefresh", "startPanicCue", etc.
+ * props:       optional Map of extra fields merged into "properties" (default: empty)
+ */
+boolean sendVehicleCommand(String commandName, Map props = [:]) {
+    logDebug("sendVehicleCommand(${commandName})")
+    String vin = state.vin
+    if (!vin) { logError("sendVehicleCommand: no VIN configured"); return false }
+    if (!ensureValidTokens()) { logError("sendVehicleCommand: token refresh failed"); return false }
+
+    Map headers = [
+        "Content-Type":   "application/json",
+        "Accept-Encoding": "gzip",
+        "Connection":     "keep-alive",
+        "User-Agent":     "okhttp/4.12.0",
+        "Authorization":  "Bearer ${state.autoToken}",
+    ]
+    String url = "${AUTONOMIC_API_URL}/command/vehicles/${vin}/commands"
+    Map bodyMap = [
+        properties: props ?: [:],
+        tags:       [:],
+        type:       commandName,
+        wakeUp:     true,
+    ]
+    String bodyJson = JsonOutput.toJson(bodyMap)
+
+    boolean success = false
+    try {
+        httpPost([
+            uri:                url,
+            headers:            headers,
+            body:               bodyJson,
+            requestContentType: "application/json",
+            contentType:        "application/json",
+        ]) { resp ->
+            if (resp.status >= 200 && resp.status < 300) {
+                success = true
+                logDebug("sendVehicleCommand(${commandName}): OK — HTTP ${resp.status}")
+            } else {
+                logError("sendVehicleCommand(${commandName}): HTTP ${resp.status} — ${resp.data}")
+            }
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("sendVehicleCommand(${commandName}): HTTP ${e.statusCode} — ${errBody ?: e.message}")
+    } catch (Exception e) {
+        logError("sendVehicleCommand(${commandName}): ${e.message}")
+    }
+    return success
+}
+
+/**
+ * Enable or disable Guard Mode via the Ford MPS API.
+ * Guard mode uses a completely different endpoint, auth format, and HTTP methods
+ * from the Autonomic API — it cannot use sendVehicleCommand().
+ *
+ * action: "enable" (HTTP PUT) or "disable" (HTTP DELETE)
+ *
+ * Auth uses "auth-token: {fordToken}" — NOT "Authorization: Bearer".
+ * Mirrors fordpass_bridge.py::set_guard_mode() / del_guard_mode()
+ */
+boolean sendGuardModeCommand(String action) {
+    logDebug("sendGuardModeCommand(${action})")
+    String vin = state.vin
+    if (!vin) { logError("sendGuardModeCommand: no VIN configured"); return false }
+    if (!ensureValidTokens()) { logError("sendGuardModeCommand: token refresh failed"); return false }
+
+    Map regionCfg = REGIONS[state.region ?: "usa"]
+    String url = "${FORD_MPS_API}/gmfi/v1/session"
+    Map headers = [
+        "Accept-Encoding": "gzip",
+        "Connection":      "keep-alive",
+        "User-Agent":      "okhttp/4.12.0",
+        "Content-Type":    "application/json",
+        "auth-token":      state.fordToken,      // Ford MPS uses auth-token, not Bearer
+        "Application-Id":  regionCfg.app_id,
+        "X-Vin":           vin,
+    ]
+
+    boolean success = false
+    try {
+        if (action == "enable") {
+            httpPut([uri: url, headers: headers, contentType: "application/json"]) { resp ->
+                success = (resp.status >= 200 && resp.status < 300)
+                logDebug("sendGuardModeCommand(enable): HTTP ${resp.status}")
+            }
+        } else {
+            httpDelete([uri: url, headers: headers, contentType: "application/json"]) { resp ->
+                success = (resp.status >= 200 && resp.status < 300)
+                logDebug("sendGuardModeCommand(disable): HTTP ${resp.status}")
+            }
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("sendGuardModeCommand(${action}): HTTP ${e.statusCode} — ${errBody ?: e.message}")
+    } catch (Exception e) {
+        logError("sendGuardModeCommand(${action}): ${e.class.simpleName} — ${e.message}")
+    }
+    return success
+}
+
+// ---------------------------------------------------------------------------
+// Child device management
+// ---------------------------------------------------------------------------
+
+private String childDeviceId(String vin) { return "fordpass-${vin}" }
+
+private void ensureChildDevice(String vin) {
+    String devId = childDeviceId(vin)
+    def existing = getChildDevice(devId)
+    if (!existing) {
+        logInfo("ensureChildDevice: creating child device for VIN ${vin}")
+        addChildDevice(
+            "fordpass-hubitat",         // namespace (must match driver definition)
+            "FordPass Vehicle",         // driver name
+            devId,
+            null,
+            [
+                name:  "FordPass Vehicle",
+                label: "Ford Vehicle ${vin}",
+                isComponent: false,
+            ]
+        )
+    } else {
+        logDebug("ensureChildDevice: child device already exists for VIN ${vin}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Synchronous HTTP POST.
+ * Returns the parsed JSON response body as a Map/List, or null on failure.
+ * Used during the setup flow where async is not needed.
+ */
+private Map httpPostSync(String url, String body, Map headers) {
+    Map result = null
+    try {
+        httpPost([
+            uri:                url,
+            headers:            headers,
+            body:               body,
+            // requestContentType tells Hubitat how to encode/send the body.
+            // contentType tells Hubitat how to PARSE the response.
+            // These two are independent — Ford/Autonomic always respond with JSON
+            // regardless of whether we POST form-encoded or JSON data.
+            // Check both title-case and lowercase keys since callers may use either.
+            requestContentType: (headers["Content-Type"] ?: headers["content-type"]) ?: "application/json",
+            contentType:        "application/json",
+        ]) { resp ->
+            if (resp.data != null) {
+                result = resp.data instanceof Map ? resp.data as Map : null
+            }
+            logDebug("httpPostSync ${url}: HTTP ${resp.status}")
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        // Log the response body — critical for diagnosing 400/401 errors from Ford/Autonomic
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("httpPostSync ${url}: HTTP ${e.statusCode} — body: ${errBody ?: e.message}")
+        // Some Ford endpoints return non-200 with valid JSON — try to parse anyway
+        try { result = new JsonSlurper().parseText(errBody ?: "{}") as Map }
+        catch (Exception ignored) {}
+    } catch (Exception e) {
+        logError("httpPostSync ${url}: ${e.class.simpleName} — ${e.message}")
+    }
+    return result
+}
+
+/**
+ * Extract a single query-parameter value from a URL string.
+ * parse_qs equivalent.
+ */
+private String extractQueryParam(String url, String paramName) {
+    try {
+        String query = url.contains("?") ? url.split("\\?", 2)[1] : url
+        for (String pair : query.split("&")) {
+            String[] kv = pair.split("=", 2)
+            if (kv[0] == paramName) {
+                return java.net.URLDecoder.decode(kv[1], "UTF-8")
+            }
+        }
+    } catch (Exception e) {
+        logError("extractQueryParam: ${e.message}")
+    }
+    return null
+}
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+private void logDebug(String msg) { if (settings.enableDebugLog) log.debug "[FordPass] ${msg}" }
+private void logInfo(String msg)  { log.info  "[FordPass] ${msg}" }
+private void logWarn(String msg)  { log.warn  "[FordPass] ${msg}" }
+private void logError(String msg) { log.error "[FordPass] ${msg}" }

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -323,10 +323,10 @@ private void parseDoorStatusArray(def doorList) {
             def side = entry?.vehicleSide?.toString()?.toUpperCase()
             String norm = normaliseDoor(val)
 
-            if      (door == "FRONT_LEFT"  || (door == "UNSPECIFIED_FRONT" && side == "LH")) sendEvent(name: "doorStatusDriver",    value: norm)
-            else if (door == "FRONT_RIGHT" || (door == "UNSPECIFIED_FRONT" && side == "RH")) sendEvent(name: "doorStatusPassenger", value: norm)
-            else if (door == "REAR_LEFT"   || (door == "UNSPECIFIED_REAR"  && side == "LH")) sendEvent(name: "doorStatusRearLeft",  value: norm)
-            else if (door == "REAR_RIGHT"  || (door == "UNSPECIFIED_REAR"  && side == "RH")) sendEvent(name: "doorStatusRearRight", value: norm)
+            if      (door == "FRONT_LEFT"  || (door == "UNSPECIFIED_FRONT" && side in ["LH", "DRIVER"]))    sendEvent(name: "doorStatusDriver",    value: norm)
+            else if (door == "FRONT_RIGHT" || (door == "UNSPECIFIED_FRONT" && side in ["RH", "PASSENGER"])) sendEvent(name: "doorStatusPassenger", value: norm)
+            else if (door == "REAR_LEFT"   || (door == "UNSPECIFIED_REAR"  && side in ["LH", "DRIVER"]))    sendEvent(name: "doorStatusRearLeft",  value: norm)
+            else if (door == "REAR_RIGHT"  || (door == "UNSPECIFIED_REAR"  && side in ["RH", "PASSENGER"])) sendEvent(name: "doorStatusRearRight", value: norm)
             else if (door == "HOOD")                                                          sendEvent(name: "doorStatusHood",      value: norm)
             else if (door in ["TAILGATE","TRUNK","LIFTGATE"])                                 sendEvent(name: "doorStatusTailgate",  value: norm)
         }

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -327,8 +327,9 @@ private void parseDoorStatusArray(def doorList) {
             else if (door == "FRONT_RIGHT" || (door == "UNSPECIFIED_FRONT" && side in ["RH", "PASSENGER"])) sendEvent(name: "doorStatusPassenger", value: norm)
             else if (door == "REAR_LEFT"   || (door == "UNSPECIFIED_REAR"  && side in ["LH", "DRIVER"]))    sendEvent(name: "doorStatusRearLeft",  value: norm)
             else if (door == "REAR_RIGHT"  || (door == "UNSPECIFIED_REAR"  && side in ["RH", "PASSENGER"])) sendEvent(name: "doorStatusRearRight", value: norm)
-            else if (door == "HOOD")                                                          sendEvent(name: "doorStatusHood",      value: norm)
-            else if (door in ["TAILGATE","TRUNK","LIFTGATE"])                                 sendEvent(name: "doorStatusTailgate",  value: norm)
+            else if (door == "HOOD")                                                                          sendEvent(name: "doorStatusHood",      value: norm)
+            else if (door in ["TAILGATE", "INNER_TAILGATE", "TRUNK", "LIFTGATE"])                            sendEvent(name: "doorStatusTailgate",  value: norm)
+            else logDebug("parseDoorStatusArray: unmatched entry vehicleDoor=${door} vehicleSide=${side} value=${val}")
         }
     } catch (Exception e) { logDebug("parseDoorStatusArray: ${e.message}") }
 }

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -148,14 +148,16 @@ def disableDebugLog() {
 def lock() {
     logInfo("lock()")
     if (parent.sendVehicleCommand("lock")) {
-        sendEvent(name: "lock", value: "locked")
+        sendEvent(name: "lock",      value: "locked")
+        sendEvent(name: "lockState", value: "LOCKED")
     }
 }
 
 def unlock() {
     logInfo("unlock()")
     if (parent.sendVehicleCommand("unlock")) {
-        sendEvent(name: "lock", value: "unlocked")
+        sendEvent(name: "lock",      value: "unlocked")
+        sendEvent(name: "lockState", value: "UNLOCKED")
     }
 }
 
@@ -312,6 +314,24 @@ private void parseMetrics(def metrics) {
 private void parseDoorLockArray(def lockList) {
     if (!lockList) return
     try {
+        // ALL_DOORS is an authoritative aggregate entry present on Mach-E and others.
+        // Individual door entries (e.g. UNSPECIFIED_FRONT) can lag behind the aggregate
+        // after an auto-lock event, causing a false PARTLY_LOCKED reading. Use ALL_DOORS
+        // directly when available to avoid counting a stale individual entry against it.
+        def allDoors = lockList.find { it?.vehicleDoor?.toString()?.toUpperCase() == "ALL_DOORS" }
+        if (allDoors) {
+            def val = allDoors?.value?.toString()?.toUpperCase()
+            if (val == "LOCKED") {
+                sendEvent(name: "lock", value: "locked")
+                sendEvent(name: "lockState", value: "LOCKED")
+            } else if (val != null) {
+                sendEvent(name: "lock", value: "unlocked")
+                sendEvent(name: "lockState", value: "UNLOCKED")
+            }
+            return
+        }
+
+        // Fallback for vehicles without an ALL_DOORS aggregate entry
         int total = 0, locked = 0
         lockList.each { entry ->
             def val = entry?.value?.toString()?.toUpperCase()

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -50,6 +50,9 @@ metadata {
         command "requestStatusRefresh"   // ask the vehicle to push an update
         command "enableGuardMode"
         command "disableGuardMode"
+        command "preconditionStart"      // start cabin preconditioning
+        command "preconditionExtend"     // extend active preconditioning session
+        command "preconditionStop"       // stop preconditioning
 
         // --- Custom read-only attributes ---
 
@@ -195,6 +198,23 @@ def enableGuardMode() {
 def disableGuardMode() {
     logInfo("disableGuardMode()")
     parent.sendGuardModeCommand("disable")
+}
+
+def preconditionStart() {
+    logInfo("preconditionStart()")
+    // Mach-E and RCC-capable vehicles use the Ford RCC API, not the Autonomic commands endpoint
+    parent.sendRccCommand("On")
+}
+
+def preconditionExtend() {
+    logInfo("preconditionExtend()")
+    // Extending just re-sends the On command with current preferences
+    parent.sendRccCommand("On")
+}
+
+def preconditionStop() {
+    logInfo("preconditionStop()")
+    parent.sendRccCommand("Off")
 }
 
 // ---------------------------------------------------------------------------

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -273,9 +273,9 @@ private void parseMetrics(def metrics) {
     safeVal(metrics, "deepSleepStatus")  { v -> sendEvent(name: "deepSleepMode",     value: v?.toString()) }
 
     safeVal(metrics, "oilLifeRemaining") { v -> sendEvent(name: "oilLife",           value: v as BigDecimal, unit: "%") }
-    safeVal(metrics, "ambientTemp")      { v -> sendEvent(name: "temperature",        value: v as BigDecimal, unit: "°C") }
-    safeVal(metrics, "engineOilTemp")    { v -> sendEvent(name: "engineOilTemp",      value: v as BigDecimal, unit: "°C") }
-    safeVal(metrics, "coolantTemp")      { v -> sendEvent(name: "engineCoolantTemp",  value: v as BigDecimal, unit: "°C") }
+    safeVal(metrics, "ambientTemp")      { v -> if ((v as BigDecimal) != 0) sendEvent(name: "temperature",        value: v as BigDecimal, unit: "°C") }
+    safeVal(metrics, "engineOilTemp")    { v -> if ((v as BigDecimal) != 0) sendEvent(name: "engineOilTemp",      value: v as BigDecimal, unit: "°C") }
+    safeVal(metrics, "coolantTemp")      { v -> if ((v as BigDecimal) != 0) sendEvent(name: "engineCoolantTemp",  value: v as BigDecimal, unit: "°C") }
     safeVal(metrics, "vehicleSpeed")     { v -> sendEvent(name: "speed",              value: v as BigDecimal) }
 
     // --- Array metrics ---

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -1,0 +1,464 @@
+/**
+ * FordPass Vehicle — Hubitat Driver
+ *
+ * Ported from marq24/ha-fordpass (Home Assistant custom integration).
+ * Source: https://github.com/marq24/ha-fordpass
+ *
+ * Child device created and managed by the FordPass Connect app.
+ * The app calls parseVehicleData(Map) with the raw API JSON each poll cycle.
+ * Commands relay back to the app via parent.sendVehicleCommand().
+ *
+ * Capabilities exposed:
+ *   Lock                — door lock/unlock
+ *   Switch              — remote start (on = start, off = cancel)
+ *   Refresh             — trigger a manual data refresh
+ *   PresenceSensor      — vehicle GPS tracking (present/not present based on movement)
+ *
+ * Custom attributes (populated from API metrics/states):
+ *   odometer, fuelLevel, fuelRange, batterySOC, batteryRange,
+ *   tirePressureFL, tirePressureFR, tirePressureRL, tirePressureRR,
+ *   doorStatusDriver, doorStatusPassenger, doorStatusRearLeft, doorStatusRearRight,
+ *   windowStatusDriver, windowStatusPassenger, windowStatusRearLeft, windowStatusRearRight,
+ *   ignition, lockState, alarmStatus, outsideTemperature, oilLife,
+ *   chargingStatus, plugStatus, chargingPower,
+ *   latitude, longitude, speed, lastUpdated
+ *
+ * All parsing mirrors fordpass_handler.py — metric/state key names are preserved
+ * so you can cross-reference the source easily.
+ */
+
+import groovy.json.JsonSlurper
+
+metadata {
+    definition(
+        name:      "FordPass Vehicle",
+        namespace: "fordpass-hubitat",
+        author:    "Ported from marq24/ha-fordpass",
+        description: "Ford / Lincoln connected vehicle — child of FordPass Connect app"
+    ) {
+        // --- Standard Hubitat capabilities ---
+        capability "Lock"             // lock(), unlock(), attribute: lock (locked/unlocked)
+        capability "Switch"           // on() = remote start, off() = cancel remote start
+        capability "Refresh"          // refresh()
+        capability "PresenceSensor"   // attribute: presence (present/not present)
+        capability "TemperatureMeasurement"  // attribute: temperature (outside temp)
+
+        // --- Commands ---
+        command "remoteStart"
+        command "cancelRemoteStart"
+        command "honkAndFlash"
+        command "requestStatusRefresh"   // ask the vehicle to push an update
+        command "enableGuardMode"
+        command "disableGuardMode"
+
+        // --- Custom read-only attributes ---
+
+        // Distance / range
+        attribute "odometer",       "number"   // km or miles depending on region
+        attribute "fuelLevel",      "number"   // percentage 0-100
+        attribute "fuelRange",      "number"   // km or miles
+        attribute "batterySOC",     "number"   // EV/PHEV: state of charge %
+        attribute "batteryRange",   "number"   // EV/PHEV: electric range km or miles
+
+        // Tires
+        attribute "tirePressureFL", "number"   // Front Left
+        attribute "tirePressureFR", "number"   // Front Right
+        attribute "tirePressureRL", "number"   // Rear Left
+        attribute "tirePressureRR", "number"   // Rear Right
+        attribute "tirePressureUnit", "string"
+
+        // Doors  (CLOSED / OPEN / AJAR)
+        attribute "doorStatusDriver",      "string"
+        attribute "doorStatusPassenger",   "string"
+        attribute "doorStatusRearLeft",    "string"
+        attribute "doorStatusRearRight",   "string"
+        attribute "doorStatusHood",        "string"
+        attribute "doorStatusTailgate",    "string"
+
+        // Windows (CLOSED / OPEN)
+        attribute "windowStatusDriver",    "string"
+        attribute "windowStatusPassenger", "string"
+        attribute "windowStatusRearLeft",  "string"
+        attribute "windowStatusRearRight", "string"
+
+        // Ignition / lock / alarm
+        attribute "ignition",     "string"   // Off / On / Start
+        attribute "lockState",    "string"   // LOCKED / PARTLY_LOCKED / UNLOCKED
+        attribute "alarmStatus",  "string"
+
+        // Fluids / engine
+        attribute "oilLife",       "number"   // percentage
+        attribute "engineCoolantTemp", "number"
+        attribute "engineOilTemp",     "number"
+
+        // EV / charging
+        attribute "chargingStatus",     "string"   // NOT_READY / IN_PROGRESS / COMPLETE / PAUSED / SCHEDULED
+        attribute "plugStatus",         "string"   // CONNECTED / DISCONNECTED / CHARGING
+        attribute "chargingPower",      "number"   // kW
+        attribute "targetSOC",          "number"   // %
+
+        // GPS
+        attribute "latitude",    "number"
+        attribute "longitude",   "number"
+        attribute "speed",       "number"
+        attribute "heading",     "number"
+
+        // Status
+        attribute "lastUpdated", "string"
+        attribute "deepSleepMode", "string"
+    }
+
+    preferences {
+        input(name: "pressureUnit",    type: "enum",   title: "Tire pressure unit",
+              options: ["PSI": "PSI", "kPa": "kPa", "BAR": "BAR"], defaultValue: "PSI")
+        input(name: "distanceUnit",    type: "enum",   title: "Distance unit",
+              options: ["km": "km", "miles": "miles"], defaultValue: "miles")
+        input(name: "enableDebugLog",  type: "bool",   title: "Enable debug logging", defaultValue: false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+def installed()  { logInfo("installed"); initialize() }
+def updated()    { logInfo("updated");   initialize() }
+def initialize() { logDebug("initialize") }
+
+// ---------------------------------------------------------------------------
+// Standard capability commands
+// ---------------------------------------------------------------------------
+
+def lock() {
+    logInfo("lock()")
+    if (parent.sendVehicleCommand("lock")) {
+        sendEvent(name: "lock", value: "locked")
+    }
+}
+
+def unlock() {
+    logInfo("unlock()")
+    if (parent.sendVehicleCommand("unlock")) {
+        sendEvent(name: "lock", value: "unlocked")
+    }
+}
+
+def on() {
+    remoteStart()
+}
+
+def off() {
+    cancelRemoteStart()
+}
+
+def refresh() {
+    logInfo("refresh()")
+    parent.pollVehicle()
+}
+
+// ---------------------------------------------------------------------------
+// Custom commands
+// ---------------------------------------------------------------------------
+
+def remoteStart() {
+    logInfo("remoteStart()")
+    if (parent.sendVehicleCommand("remoteStart")) {
+        sendEvent(name: "switch", value: "on")
+    }
+}
+
+def cancelRemoteStart() {
+    logInfo("cancelRemoteStart()")
+    if (parent.sendVehicleCommand("cancelRemoteStart")) {
+        sendEvent(name: "switch", value: "off")
+    }
+}
+
+def honkAndFlash() {
+    logInfo("honkAndFlash()")
+    // Autonomic command name is 'startPanicCue'; duration 3 = DEFAULT in HONK_AND_FLASH enum
+    parent.sendVehicleCommand("startPanicCue", [duration: 3])
+}
+
+def requestStatusRefresh() {
+    logInfo("requestStatusRefresh()")
+    // Tells the vehicle to push a fresh status update; can take up to 5 min
+    parent.sendVehicleCommand("statusRefresh")
+}
+
+def enableGuardMode() {
+    logInfo("enableGuardMode()")
+    // Guard mode uses a separate Ford MPS API endpoint — not the Autonomic commands endpoint
+    parent.sendGuardModeCommand("enable")
+}
+
+def disableGuardMode() {
+    logInfo("disableGuardMode()")
+    parent.sendGuardModeCommand("disable")
+}
+
+// ---------------------------------------------------------------------------
+// Data parsing — called by the app after each poll
+// ---------------------------------------------------------------------------
+
+/**
+ * Entry point for incoming vehicle data from the app's pollVehicle().
+ * rawData is the parsed JSON Map from GET /api/expdashboard/v1/details/
+ *
+ * The JSON has these top-level sections (mirrors fordpass_handler.py ROOT_* constants):
+ *   vehiclestatus.metrics   — sensor readings (odometer, fuel, tires, etc.)
+ *   vehiclestatus.states    — discrete states (lock, door, ignition, etc.)
+ *   vehiclestatus.events    — event log
+ *   gps                     — location
+ */
+void parseVehicleData(Map rawData) {
+    logDebug("parseVehicleData()")
+    if (!rawData) { logWarn("parseVehicleData: null data"); return }
+
+    try {
+        def vehicleStatus = rawData.vehiclestatus ?: rawData
+
+        parseMetrics(vehicleStatus.metrics ?: [:])
+        parseStates(vehicleStatus.states   ?: [:])
+        parseGps(rawData.gps               ?: vehicleStatus.gps ?: [:])
+
+        sendEvent(name: "lastUpdated", value: new Date().toString())
+    } catch (Exception e) {
+        logError("parseVehicleData: ${e.message}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metrics parsing (fordpass_handler.py metric keys)
+// ---------------------------------------------------------------------------
+
+private void parseMetrics(def metrics) {
+    if (!metrics) return
+
+    // --- Odometer ---
+    safeMetric(metrics, "odometer") { v ->
+        sendEvent(name: "odometer", value: v as BigDecimal, unit: settings.distanceUnit ?: "miles")
+    }
+
+    // --- Fuel ---
+    safeMetric(metrics, "fuelLevel") { v ->
+        sendEvent(name: "fuelLevel", value: (v as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP), unit: "%")
+    }
+    safeMetric(metrics, "dteForMilesHvb") { v ->
+        sendEvent(name: "fuelRange", value: v as BigDecimal, unit: settings.distanceUnit ?: "miles")
+    }
+
+    // --- EV battery ---
+    safeMetric(metrics, "xevBatteryStateOfCharge") { v ->
+        sendEvent(name: "batterySOC", value: (v as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP), unit: "%")
+    }
+    safeMetric(metrics, "xevBatteryRange") { v ->
+        sendEvent(name: "batteryRange", value: v as BigDecimal, unit: settings.distanceUnit ?: "miles")
+    }
+    safeMetric(metrics, "xevPlugChargerStatus") { v ->
+        sendEvent(name: "plugStatus", value: v?.toString())
+    }
+    safeMetric(metrics, "xevBatteryChargeDisplayStatus") { v ->
+        sendEvent(name: "chargingStatus", value: v?.toString())
+        // Mirror to switch so automations can key off it
+    }
+    safeMetric(metrics, "xevChargerPowertype") { v ->
+        // power in kW — sometimes named differently
+    }
+
+    // --- Tires (key names from const_tags.py) ---
+    String pUnit = settings.pressureUnit ?: "PSI"
+    safeMetric(metrics, "tirePressureSystemStatus") { v ->
+        // aggregate; individual values below
+    }
+    safeMetric(metrics, "tirePressureFrontLeft")  { v -> sendEvent(name: "tirePressureFL", value: convertPressure(v, pUnit), unit: pUnit) }
+    safeMetric(metrics, "tirePressureFrontRight") { v -> sendEvent(name: "tirePressureFR", value: convertPressure(v, pUnit), unit: pUnit) }
+    safeMetric(metrics, "tirePressureRearLeft")   { v -> sendEvent(name: "tirePressureRL", value: convertPressure(v, pUnit), unit: pUnit) }
+    safeMetric(metrics, "tirePressureRearRight")  { v -> sendEvent(name: "tirePressureRR", value: convertPressure(v, pUnit), unit: pUnit) }
+    sendEvent(name: "tirePressureUnit", value: pUnit)
+
+    // --- Temperatures ---
+    safeMetric(metrics, "ambientTemp") { v ->
+        BigDecimal celsius = v as BigDecimal
+        sendEvent(name: "temperature", value: celsius, unit: "°C")
+        sendEvent(name: "outsideTemperature", value: celsius, unit: "°C")
+    }
+    safeMetric(metrics, "coolantTemp") { v ->
+        sendEvent(name: "engineCoolantTemp", value: v as BigDecimal, unit: "°C")
+    }
+    safeMetric(metrics, "engineOilTemp") { v ->
+        sendEvent(name: "engineOilTemp", value: v as BigDecimal, unit: "°C")
+    }
+
+    // --- Oil life ---
+    safeMetric(metrics, "oilLifeRemaining") { v ->
+        sendEvent(name: "oilLife", value: v as BigDecimal, unit: "%")
+    }
+
+    // --- Speed ---
+    safeMetric(metrics, "vehicleSpeed") { v ->
+        sendEvent(name: "speed", value: v as BigDecimal, unit: settings.distanceUnit == "miles" ? "mph" : "km/h")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// States parsing
+// ---------------------------------------------------------------------------
+
+private void parseStates(def states) {
+    if (!states) return
+
+    // --- Lock ---
+    safeState(states, "doorLockStatus") { v ->
+        sendEvent(name: "lockState", value: v?.toString())
+        // Map to Hubitat capability value
+        String hubitatLock
+        switch (v?.toString()?.toUpperCase()) {
+            case "LOCKED":        hubitatLock = "locked";   break
+            case "UNLOCKED":      hubitatLock = "unlocked"; break
+            case "PARTLY_LOCKED": hubitatLock = "unlocked"; break  // treat partial as unlocked
+            default:              hubitatLock = "unknown"
+        }
+        sendEvent(name: "lock", value: hubitatLock)
+    }
+
+    // --- Ignition ---
+    safeState(states, "ignitionStatus") { v ->
+        sendEvent(name: "ignition", value: v?.toString())
+        // Remote start is "on" when ignition is active without a key
+        sendEvent(name: "switch", value: (v?.toString()?.toUpperCase() == "START") ? "on" : "off")
+    }
+
+    // --- Doors ---
+    safeState(states, "driverDoor")          { v -> sendEvent(name: "doorStatusDriver",    value: normaliseDoor(v)) }
+    safeState(states, "passengerDoor")       { v -> sendEvent(name: "doorStatusPassenger", value: normaliseDoor(v)) }
+    safeState(states, "leftRearDoor")        { v -> sendEvent(name: "doorStatusRearLeft",  value: normaliseDoor(v)) }
+    safeState(states, "rightRearDoor")       { v -> sendEvent(name: "doorStatusRearRight", value: normaliseDoor(v)) }
+    safeState(states, "hoodDoor")            { v -> sendEvent(name: "doorStatusHood",      value: normaliseDoor(v)) }
+    safeState(states, "tailgateDoor")        { v -> sendEvent(name: "doorStatusTailgate",  value: normaliseDoor(v)) }
+
+    // --- Windows ---
+    safeState(states, "driverWindowPosition")    { v -> sendEvent(name: "windowStatusDriver",    value: normaliseWindow(v)) }
+    safeState(states, "passengerWindowPosition") { v -> sendEvent(name: "windowStatusPassenger", value: normaliseWindow(v)) }
+    safeState(states, "rearDriverWindowPos")     { v -> sendEvent(name: "windowStatusRearLeft",  value: normaliseWindow(v)) }
+    safeState(states, "rearPassWindowPos")       { v -> sendEvent(name: "windowStatusRearRight", value: normaliseWindow(v)) }
+
+    // --- Alarm ---
+    safeState(states, "alarmStatus") { v ->
+        sendEvent(name: "alarmStatus", value: v?.toString())
+    }
+
+    // --- Deep sleep ---
+    safeState(states, "deepSleepStatus") { v ->
+        sendEvent(name: "deepSleepMode", value: v?.toString())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GPS parsing
+// ---------------------------------------------------------------------------
+
+private void parseGps(def gps) {
+    if (!gps) return
+
+    def lat = gps.latitude  ?: gps.lat
+    def lon = gps.longitude ?: gps.lon ?: gps.lng
+
+    if (lat != null) {
+        sendEvent(name: "latitude",  value: lat as BigDecimal)
+        sendEvent(name: "longitude", value: lon as BigDecimal)
+        // PresenceSensor — always "present" (vehicle is on your account)
+        sendEvent(name: "presence", value: "present")
+    }
+    if (gps.heading != null) {
+        sendEvent(name: "heading", value: gps.heading as BigDecimal)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Normalisation helpers
+// ---------------------------------------------------------------------------
+
+private String normaliseDoor(def raw) {
+    switch (raw?.toString()?.toUpperCase()) {
+        case "CLOSED":    return "closed"
+        case "OPEN":      return "open"
+        case "AJAR":      return "ajar"
+        default:          return raw?.toString() ?: "unknown"
+    }
+}
+
+private String normaliseWindow(def raw) {
+    switch (raw?.toString()?.toUpperCase()) {
+        case "CLOSED":    return "closed"
+        case "OPEN":      return "open"
+        default:          return raw?.toString() ?: "unknown"
+    }
+}
+
+/**
+ * Ford API returns tire pressure in kPa internally.
+ * Convert to the user's preferred unit.
+ */
+private BigDecimal convertPressure(def kPaValue, String targetUnit) {
+    BigDecimal kPa = kPaValue as BigDecimal
+    switch (targetUnit?.toUpperCase()) {
+        case "PSI":  return (kPa * 0.145038).setScale(1, BigDecimal.ROUND_HALF_UP)
+        case "BAR":  return (kPa / 100).setScale(2, BigDecimal.ROUND_HALF_UP)
+        default:     return kPa.setScale(1, BigDecimal.ROUND_HALF_UP)  // kPa
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Safe metric / state extractors
+// ---------------------------------------------------------------------------
+
+/**
+ * metrics may be a List of {key, value, status} objects or a flat Map.
+ * Handle both shapes from the API response.
+ */
+private void safeMetric(def metrics, String key, Closure handler) {
+    try {
+        def raw = null
+        if (metrics instanceof List) {
+            def entry = metrics.find { it.key == key || it.name == key }
+            raw = entry?.value
+        } else if (metrics instanceof Map) {
+            raw = metrics[key]?.value ?: metrics[key]
+        }
+        if (raw != null) {
+            handler(raw)
+        }
+    } catch (Exception e) {
+        logDebug("safeMetric(${key}): ${e.message}")
+    }
+}
+
+/**
+ * states may also be a List or Map — same dual-shape handling.
+ */
+private void safeState(def states, String key, Closure handler) {
+    try {
+        def raw = null
+        if (states instanceof List) {
+            def entry = states.find { it.key == key || it.name == key }
+            raw = entry?.value
+        } else if (states instanceof Map) {
+            raw = states[key]?.value ?: states[key]
+        }
+        if (raw != null) {
+            handler(raw)
+        }
+    } catch (Exception e) {
+        logDebug("safeState(${key}): ${e.message}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+private void logDebug(String msg) { if (settings.enableDebugLog) log.debug "[FordPass Vehicle] ${msg}" }
+private void logInfo(String msg)  { log.info  "[FordPass Vehicle] ${msg}" }
+private void logWarn(String msg)  { log.warn  "[FordPass Vehicle] ${msg}" }
+private void logError(String msg) { log.error "[FordPass Vehicle] ${msg}" }

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -127,7 +127,19 @@ metadata {
 
 def installed()  { logInfo("installed"); initialize() }
 def updated()    { logInfo("updated");   initialize() }
-def initialize() { logDebug("initialize") }
+def initialize() {
+    logDebug("initialize")
+    if (settings.enableDebugLog) {
+        runIn(7200, "disableDebugLog")
+    } else {
+        unschedule("disableDebugLog")
+    }
+}
+
+def disableDebugLog() {
+    logInfo("Debug logging automatically disabled after 2 hours")
+    device.updateSetting("enableDebugLog", [value: false, type: "bool"])
+}
 
 // ---------------------------------------------------------------------------
 // Standard capability commands

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -203,25 +203,22 @@ def disableGuardMode() {
 
 /**
  * Entry point for incoming vehicle data from the app's pollVehicle().
- * rawData is the parsed JSON Map from GET /api/expdashboard/v1/details/
  *
- * The JSON has these top-level sections (mirrors fordpass_handler.py ROOT_* constants):
- *   vehiclestatus.metrics   — sensor readings (odometer, fuel, tires, etc.)
- *   vehiclestatus.states    — discrete states (lock, door, ignition, etc.)
- *   vehiclestatus.events    — event log
- *   gps                     — location
+ * Actual API structure (mirrors fordpass_handler.py ROOT_* constants):
+ *   rawData.metrics  — Map<String, {value, updateTime}> for scalars,
+ *                      List<{value, vehicleDoor/vehicleWheel/...}> for arrays
+ *   rawData.states   — only deviceConnectivity / commandPreclusion (rarely useful)
+ *   rawData.metrics.position.value.location — GPS {lat, lon, alt}
+ *
+ * NOTE: there is NO "vehiclestatus" wrapper — metrics is at the root.
  */
 void parseVehicleData(Map rawData) {
     logDebug("parseVehicleData()")
     if (!rawData) { logWarn("parseVehicleData: null data"); return }
 
     try {
-        def vehicleStatus = rawData.vehiclestatus ?: rawData
-
-        parseMetrics(vehicleStatus.metrics ?: [:])
-        parseStates(vehicleStatus.states   ?: [:])
-        parseGps(rawData.gps               ?: vehicleStatus.gps ?: [:])
-
+        def metrics = rawData.metrics ?: [:]
+        parseMetrics(metrics)
         sendEvent(name: "lastUpdated", value: new Date().toString())
     } catch (Exception e) {
         logError("parseVehicleData: ${e.message}")
@@ -229,171 +226,177 @@ void parseVehicleData(Map rawData) {
 }
 
 // ---------------------------------------------------------------------------
-// Metrics parsing (fordpass_handler.py metric keys)
+// Metrics parsing
 // ---------------------------------------------------------------------------
 
 private void parseMetrics(def metrics) {
     if (!metrics) return
 
-    // --- Odometer ---
-    safeMetric(metrics, "odometer") { v ->
-        sendEvent(name: "odometer", value: v as BigDecimal, unit: settings.distanceUnit ?: "miles")
-    }
+    // --- Scalar metrics: metrics[key] = { "value": <scalar>, "updateTime": "..." } ---
 
-    // --- Fuel ---
-    safeMetric(metrics, "fuelLevel") { v ->
-        sendEvent(name: "fuelLevel", value: (v as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP), unit: "%")
-    }
-    safeMetric(metrics, "dteForMilesHvb") { v ->
-        sendEvent(name: "fuelRange", value: v as BigDecimal, unit: settings.distanceUnit ?: "miles")
-    }
+    // Ford API always returns distances in kilometres — convert if user prefers miles
+    safeVal(metrics, "odometer")         { v -> sendEvent(name: "odometer",     value: convertDistance(v), unit: settings.distanceUnit ?: "miles") }
 
-    // --- EV battery ---
-    safeMetric(metrics, "xevBatteryStateOfCharge") { v ->
-        sendEvent(name: "batterySOC", value: (v as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP), unit: "%")
-    }
-    safeMetric(metrics, "xevBatteryRange") { v ->
-        sendEvent(name: "batteryRange", value: v as BigDecimal, unit: settings.distanceUnit ?: "miles")
-    }
-    safeMetric(metrics, "xevPlugChargerStatus") { v ->
-        sendEvent(name: "plugStatus", value: v?.toString())
-    }
-    safeMetric(metrics, "xevBatteryChargeDisplayStatus") { v ->
-        sendEvent(name: "chargingStatus", value: v?.toString())
-        // Mirror to switch so automations can key off it
-    }
-    safeMetric(metrics, "xevChargerPowertype") { v ->
-        // power in kW — sometimes named differently
-    }
+    safeVal(metrics, "fuelLevel")        { v -> sendEvent(name: "fuelLevel",    value: (v as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP), unit: "%") }
+    safeVal(metrics, "fuelRange")        { v -> sendEvent(name: "fuelRange",    value: convertDistance(v), unit: settings.distanceUnit ?: "miles") }
 
-    // --- Tires (key names from const_tags.py) ---
-    String pUnit = settings.pressureUnit ?: "PSI"
-    safeMetric(metrics, "tirePressureSystemStatus") { v ->
-        // aggregate; individual values below
-    }
-    safeMetric(metrics, "tirePressureFrontLeft")  { v -> sendEvent(name: "tirePressureFL", value: convertPressure(v, pUnit), unit: pUnit) }
-    safeMetric(metrics, "tirePressureFrontRight") { v -> sendEvent(name: "tirePressureFR", value: convertPressure(v, pUnit), unit: pUnit) }
-    safeMetric(metrics, "tirePressureRearLeft")   { v -> sendEvent(name: "tirePressureRL", value: convertPressure(v, pUnit), unit: pUnit) }
-    safeMetric(metrics, "tirePressureRearRight")  { v -> sendEvent(name: "tirePressureRR", value: convertPressure(v, pUnit), unit: pUnit) }
-    sendEvent(name: "tirePressureUnit", value: pUnit)
+    safeVal(metrics, "xevBatteryStateOfCharge") { v -> sendEvent(name: "batterySOC",   value: (v as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP), unit: "%") }
+    safeVal(metrics, "xevBatteryRange")  { v -> sendEvent(name: "batteryRange", value: convertDistance(v), unit: settings.distanceUnit ?: "miles") }
+    safeVal(metrics, "xevPlugChargerStatus")          { v -> sendEvent(name: "plugStatus",     value: v?.toString()) }
+    safeVal(metrics, "xevBatteryChargeDisplayStatus") { v -> sendEvent(name: "chargingStatus", value: v?.toString()) }
 
-    // --- Temperatures ---
-    safeMetric(metrics, "ambientTemp") { v ->
-        BigDecimal celsius = v as BigDecimal
-        sendEvent(name: "temperature", value: celsius, unit: "°C")
-        sendEvent(name: "outsideTemperature", value: celsius, unit: "°C")
-    }
-    safeMetric(metrics, "coolantTemp") { v ->
-        sendEvent(name: "engineCoolantTemp", value: v as BigDecimal, unit: "°C")
-    }
-    safeMetric(metrics, "engineOilTemp") { v ->
-        sendEvent(name: "engineOilTemp", value: v as BigDecimal, unit: "°C")
-    }
-
-    // --- Oil life ---
-    safeMetric(metrics, "oilLifeRemaining") { v ->
-        sendEvent(name: "oilLife", value: v as BigDecimal, unit: "%")
-    }
-
-    // --- Speed ---
-    safeMetric(metrics, "vehicleSpeed") { v ->
-        sendEvent(name: "speed", value: v as BigDecimal, unit: settings.distanceUnit == "miles" ? "mph" : "km/h")
-    }
-}
-
-// ---------------------------------------------------------------------------
-// States parsing
-// ---------------------------------------------------------------------------
-
-private void parseStates(def states) {
-    if (!states) return
-
-    // --- Lock ---
-    safeState(states, "doorLockStatus") { v ->
-        sendEvent(name: "lockState", value: v?.toString())
-        // Map to Hubitat capability value
-        String hubitatLock
-        switch (v?.toString()?.toUpperCase()) {
-            case "LOCKED":        hubitatLock = "locked";   break
-            case "UNLOCKED":      hubitatLock = "unlocked"; break
-            case "PARTLY_LOCKED": hubitatLock = "unlocked"; break  // treat partial as unlocked
-            default:              hubitatLock = "unknown"
-        }
-        sendEvent(name: "lock", value: hubitatLock)
-    }
-
-    // --- Ignition ---
-    safeState(states, "ignitionStatus") { v ->
+    safeVal(metrics, "ignitionStatus")   { v ->
         sendEvent(name: "ignition", value: v?.toString())
-        // Remote start is "on" when ignition is active without a key
-        sendEvent(name: "switch", value: (v?.toString()?.toUpperCase() == "START") ? "on" : "off")
+        sendEvent(name: "switch", value: (v?.toString()?.toUpperCase() in ["START", "RUN"]) ? "on" : "off")
     }
+    safeVal(metrics, "alarmStatus")      { v -> sendEvent(name: "alarmStatus",       value: v?.toString()) }
+    safeVal(metrics, "deepSleepStatus")  { v -> sendEvent(name: "deepSleepMode",     value: v?.toString()) }
 
-    // --- Doors ---
-    safeState(states, "driverDoor")          { v -> sendEvent(name: "doorStatusDriver",    value: normaliseDoor(v)) }
-    safeState(states, "passengerDoor")       { v -> sendEvent(name: "doorStatusPassenger", value: normaliseDoor(v)) }
-    safeState(states, "leftRearDoor")        { v -> sendEvent(name: "doorStatusRearLeft",  value: normaliseDoor(v)) }
-    safeState(states, "rightRearDoor")       { v -> sendEvent(name: "doorStatusRearRight", value: normaliseDoor(v)) }
-    safeState(states, "hoodDoor")            { v -> sendEvent(name: "doorStatusHood",      value: normaliseDoor(v)) }
-    safeState(states, "tailgateDoor")        { v -> sendEvent(name: "doorStatusTailgate",  value: normaliseDoor(v)) }
+    safeVal(metrics, "oilLifeRemaining") { v -> sendEvent(name: "oilLife",           value: v as BigDecimal, unit: "%") }
+    safeVal(metrics, "ambientTemp")      { v -> sendEvent(name: "temperature",        value: v as BigDecimal, unit: "°C") }
+    safeVal(metrics, "engineOilTemp")    { v -> sendEvent(name: "engineOilTemp",      value: v as BigDecimal, unit: "°C") }
+    safeVal(metrics, "coolantTemp")      { v -> sendEvent(name: "engineCoolantTemp",  value: v as BigDecimal, unit: "°C") }
+    safeVal(metrics, "vehicleSpeed")     { v -> sendEvent(name: "speed",              value: v as BigDecimal) }
 
-    // --- Windows ---
-    safeState(states, "driverWindowPosition")    { v -> sendEvent(name: "windowStatusDriver",    value: normaliseWindow(v)) }
-    safeState(states, "passengerWindowPosition") { v -> sendEvent(name: "windowStatusPassenger", value: normaliseWindow(v)) }
-    safeState(states, "rearDriverWindowPos")     { v -> sendEvent(name: "windowStatusRearLeft",  value: normaliseWindow(v)) }
-    safeState(states, "rearPassWindowPos")       { v -> sendEvent(name: "windowStatusRearRight", value: normaliseWindow(v)) }
+    // --- Array metrics ---
 
-    // --- Alarm ---
-    safeState(states, "alarmStatus") { v ->
-        sendEvent(name: "alarmStatus", value: v?.toString())
-    }
+    // doorLockStatus: [{value:"LOCKED|UNLOCKED", vehicleDoor:"FRONT_LEFT|...", vehicleSide:"LH|RH"}, ...]
+    parseDoorLockArray(metrics.doorLockStatus)
 
-    // --- Deep sleep ---
-    safeState(states, "deepSleepStatus") { v ->
-        sendEvent(name: "deepSleepMode", value: v?.toString())
-    }
+    // doorStatus: [{value:"CLOSED|OPEN|INVALID", vehicleDoor:"...", vehicleSide:"..."}, ...]
+    parseDoorStatusArray(metrics.doorStatus)
+
+    // windowStatus: [{value:{doubleRange:{lowerBound:0.0,upperBound:0.0}}, vehicleWindow:"...", vehicleSide:"..."}, ...]
+    parseWindowStatusArray(metrics.windowStatus)
+
+    // tirePressure: [{value:<kPa>, vehicleWheel:"FRONT_LEFT|FRONT_RIGHT|REAR_LEFT|REAR_RIGHT"}, ...]
+    parseTirePressureArray(metrics.tirePressure)
+
+    // GPS: metrics.position.value.location → {lat, lon, alt}
+    parsePosition(metrics.position?.value?.location)
+}
+
+private void parseDoorLockArray(def lockList) {
+    if (!lockList) return
+    try {
+        int total = 0, locked = 0
+        lockList.each { entry ->
+            def val = entry?.value?.toString()?.toUpperCase()
+            if (val != null) { total++; if (val == "LOCKED") locked++ }
+        }
+        if (total == 0) return
+        String lockState
+        if (locked >= total)    { lockState = "LOCKED";        sendEvent(name: "lock", value: "locked") }
+        else if (locked > 0)    { lockState = "PARTLY_LOCKED"; sendEvent(name: "lock", value: "unlocked") }
+        else                    { lockState = "UNLOCKED";       sendEvent(name: "lock", value: "unlocked") }
+        sendEvent(name: "lockState", value: lockState)
+    } catch (Exception e) { logDebug("parseDoorLockArray: ${e.message}") }
+}
+
+private void parseDoorStatusArray(def doorList) {
+    if (!doorList) return
+    try {
+        doorList.each { entry ->
+            def val  = entry?.value?.toString()?.toUpperCase()
+            def door = entry?.vehicleDoor?.toString()?.toUpperCase()
+            def side = entry?.vehicleSide?.toString()?.toUpperCase()
+            String norm = normaliseDoor(val)
+
+            if      (door == "FRONT_LEFT"  || (door == "UNSPECIFIED_FRONT" && side == "LH")) sendEvent(name: "doorStatusDriver",    value: norm)
+            else if (door == "FRONT_RIGHT" || (door == "UNSPECIFIED_FRONT" && side == "RH")) sendEvent(name: "doorStatusPassenger", value: norm)
+            else if (door == "REAR_LEFT"   || (door == "UNSPECIFIED_REAR"  && side == "LH")) sendEvent(name: "doorStatusRearLeft",  value: norm)
+            else if (door == "REAR_RIGHT"  || (door == "UNSPECIFIED_REAR"  && side == "RH")) sendEvent(name: "doorStatusRearRight", value: norm)
+            else if (door == "HOOD")                                                          sendEvent(name: "doorStatusHood",      value: norm)
+            else if (door in ["TAILGATE","TRUNK","LIFTGATE"])                                 sendEvent(name: "doorStatusTailgate",  value: norm)
+        }
+    } catch (Exception e) { logDebug("parseDoorStatusArray: ${e.message}") }
+}
+
+private void parseWindowStatusArray(def windowList) {
+    if (!windowList) return
+    try {
+        windowList.each { entry ->
+            def window = entry?.vehicleWindow?.toString()?.toUpperCase()
+            def side   = entry?.vehicleSide?.toString()?.toUpperCase()
+            def dr     = entry?.value?.doubleRange
+            boolean open = dr && (dr.lowerBound != 0.0 || dr.upperBound != 0.0)
+            String norm  = open ? "open" : "closed"
+
+            if      (window == "FRONT_LEFT"  || (window?.contains("FRONT") && side == "LH")) sendEvent(name: "windowStatusDriver",    value: norm)
+            else if (window == "FRONT_RIGHT" || (window?.contains("FRONT") && side == "RH")) sendEvent(name: "windowStatusPassenger", value: norm)
+            else if (window == "REAR_LEFT"   || (window?.contains("REAR")  && side == "LH")) sendEvent(name: "windowStatusRearLeft",  value: norm)
+            else if (window == "REAR_RIGHT"  || (window?.contains("REAR")  && side == "RH")) sendEvent(name: "windowStatusRearRight", value: norm)
+        }
+    } catch (Exception e) { logDebug("parseWindowStatusArray: ${e.message}") }
+}
+
+private void parseTirePressureArray(def tireList) {
+    if (!tireList) return
+    try {
+        String pUnit = settings.pressureUnit ?: "PSI"
+        tireList.each { entry ->
+            def wheel = entry?.vehicleWheel?.toString()?.toUpperCase()
+            def val   = entry?.value
+            if (val == null) return
+            BigDecimal converted = convertPressure(val, pUnit)
+
+            if      (wheel == "FRONT_LEFT")  sendEvent(name: "tirePressureFL", value: converted, unit: pUnit)
+            else if (wheel == "FRONT_RIGHT") sendEvent(name: "tirePressureFR", value: converted, unit: pUnit)
+            else if (wheel == "REAR_LEFT")   sendEvent(name: "tirePressureRL", value: converted, unit: pUnit)
+            else if (wheel == "REAR_RIGHT")  sendEvent(name: "tirePressureRR", value: converted, unit: pUnit)
+        }
+        sendEvent(name: "tirePressureUnit", value: pUnit)
+    } catch (Exception e) { logDebug("parseTirePressureArray: ${e.message}") }
+}
+
+private void parsePosition(def location) {
+    if (!location) return
+    try {
+        def lat = location.lat ?: location.latitude
+        def lon = location.lon ?: location.longitude
+        if (lat != null && lon != null) {
+            sendEvent(name: "latitude",  value: lat as BigDecimal)
+            sendEvent(name: "longitude", value: lon as BigDecimal)
+            sendEvent(name: "presence",  value: "present")
+        }
+        if (location.alt != null) {
+            // altitude available but no attribute for it; log for debugging
+            logDebug("parsePosition: alt=${location.alt}")
+        }
+    } catch (Exception e) { logDebug("parsePosition: ${e.message}") }
 }
 
 // ---------------------------------------------------------------------------
-// GPS parsing
+// Helpers
 // ---------------------------------------------------------------------------
 
-private void parseGps(def gps) {
-    if (!gps) return
-
-    def lat = gps.latitude  ?: gps.lat
-    def lon = gps.longitude ?: gps.lon ?: gps.lng
-
-    if (lat != null) {
-        sendEvent(name: "latitude",  value: lat as BigDecimal)
-        sendEvent(name: "longitude", value: lon as BigDecimal)
-        // PresenceSensor — always "present" (vehicle is on your account)
-        sendEvent(name: "presence", value: "present")
-    }
-    if (gps.heading != null) {
-        sendEvent(name: "heading", value: gps.heading as BigDecimal)
-    }
+/** Scalar metric extractor: metrics[key] = { "value": <v>, ... } */
+private void safeVal(def metrics, String key, Closure handler) {
+    try {
+        def raw = metrics[key]?.value
+        if (raw != null) handler(raw)
+    } catch (Exception e) { logDebug("safeVal(${key}): ${e.message}") }
 }
-
-// ---------------------------------------------------------------------------
-// Normalisation helpers
-// ---------------------------------------------------------------------------
 
 private String normaliseDoor(def raw) {
     switch (raw?.toString()?.toUpperCase()) {
-        case "CLOSED":    return "closed"
-        case "OPEN":      return "open"
-        case "AJAR":      return "ajar"
-        default:          return raw?.toString() ?: "unknown"
+        case "CLOSED":  return "closed"
+        case "OPEN":    return "open"
+        case "AJAR":    return "ajar"
+        default:        return raw?.toString()?.toLowerCase() ?: "unknown"
     }
 }
 
-private String normaliseWindow(def raw) {
-    switch (raw?.toString()?.toUpperCase()) {
-        case "CLOSED":    return "closed"
-        case "OPEN":      return "open"
-        default:          return raw?.toString() ?: "unknown"
+/**
+ * Ford API returns distances in kilometres.
+ * Convert to miles when the driver preference is set to "miles".
+ */
+private BigDecimal convertDistance(def kmValue) {
+    BigDecimal km = kmValue as BigDecimal
+    if ((settings.distanceUnit ?: "miles") == "miles") {
+        return (km / 1.609344).setScale(1, BigDecimal.ROUND_HALF_UP)
     }
+    return km.setScale(1, BigDecimal.ROUND_HALF_UP)
 }
 
 /**
@@ -406,51 +409,6 @@ private BigDecimal convertPressure(def kPaValue, String targetUnit) {
         case "PSI":  return (kPa * 0.145038).setScale(1, BigDecimal.ROUND_HALF_UP)
         case "BAR":  return (kPa / 100).setScale(2, BigDecimal.ROUND_HALF_UP)
         default:     return kPa.setScale(1, BigDecimal.ROUND_HALF_UP)  // kPa
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Safe metric / state extractors
-// ---------------------------------------------------------------------------
-
-/**
- * metrics may be a List of {key, value, status} objects or a flat Map.
- * Handle both shapes from the API response.
- */
-private void safeMetric(def metrics, String key, Closure handler) {
-    try {
-        def raw = null
-        if (metrics instanceof List) {
-            def entry = metrics.find { it.key == key || it.name == key }
-            raw = entry?.value
-        } else if (metrics instanceof Map) {
-            raw = metrics[key]?.value ?: metrics[key]
-        }
-        if (raw != null) {
-            handler(raw)
-        }
-    } catch (Exception e) {
-        logDebug("safeMetric(${key}): ${e.message}")
-    }
-}
-
-/**
- * states may also be a List or Map — same dual-shape handling.
- */
-private void safeState(def states, String key, Closure handler) {
-    try {
-        def raw = null
-        if (states instanceof List) {
-            def entry = states.find { it.key == key || it.name == key }
-            raw = entry?.value
-        } else if (states instanceof Map) {
-            raw = states[key]?.value ?: states[key]
-        }
-        if (raw != null) {
-            handler(raw)
-        }
-    } catch (Exception e) {
-        logDebug("safeState(${key}): ${e.message}")
     }
 }
 

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -116,6 +116,7 @@ metadata {
               options: ["PSI": "PSI", "kPa": "kPa", "BAR": "BAR"], defaultValue: "PSI")
         input(name: "distanceUnit",    type: "enum",   title: "Distance unit",
               options: ["km": "km", "miles": "miles"], defaultValue: "miles")
+        input(name: "geofenceRadius",  type: "number", title: "Home geofence radius (metres)", defaultValue: 200)
         input(name: "enableDebugLog",  type: "bool",   title: "Enable debug logging", defaultValue: false)
     }
 }
@@ -369,20 +370,29 @@ private void parseTirePressureArray(def tireList) {
     } catch (Exception e) { logDebug("parseTirePressureArray: ${e.message}") }
 }
 
-private void parsePosition(def location) {
-    if (!location) return
+private void parsePosition(def fordLocation) {
+    if (!fordLocation) return
     try {
-        def lat = location.lat ?: location.latitude
-        def lon = location.lon ?: location.longitude
-        if (lat != null && lon != null) {
-            sendEvent(name: "latitude",  value: lat as BigDecimal)
-            sendEvent(name: "longitude", value: lon as BigDecimal)
-            sendEvent(name: "presence",  value: "present")
+        def lat = fordLocation.lat ?: fordLocation.latitude
+        def lon = fordLocation.lon ?: fordLocation.longitude
+        if (lat == null || lon == null) return
+
+        sendEvent(name: "latitude",  value: lat as BigDecimal)
+        sendEvent(name: "longitude", value: lon as BigDecimal)
+
+        // location (no qualifier) is the Hubitat hub's location object, always available in drivers
+        if (location.latitude == null || location.longitude == null) {
+            logWarn("parsePosition: hub location not configured — set lat/lon under Settings → Location to enable geofence presence")
+            return
         }
-        if (location.alt != null) {
-            // altitude available but no attribute for it; log for debugging
-            logDebug("parsePosition: alt=${location.alt}")
-        }
+        BigDecimal hubLat = location.latitude as BigDecimal
+        BigDecimal hubLon = location.longitude as BigDecimal
+
+        BigDecimal distanceM = haversineDistance(lat as BigDecimal, lon as BigDecimal, hubLat, hubLon)
+        int radius = (settings.geofenceRadius ?: 200) as int
+        String presence = distanceM <= radius ? "present" : "not present"
+        logDebug("parsePosition: distance=${distanceM.setScale(0, BigDecimal.ROUND_HALF_UP)}m radius=${radius}m → ${presence}")
+        sendEvent(name: "presence", value: presence)
     } catch (Exception e) { logDebug("parsePosition: ${e.message}") }
 }
 
@@ -430,6 +440,19 @@ private BigDecimal convertPressure(def kPaValue, String targetUnit) {
         case "BAR":  return (kPa / 100).setScale(2, BigDecimal.ROUND_HALF_UP)
         default:     return kPa.setScale(1, BigDecimal.ROUND_HALF_UP)  // kPa
     }
+}
+
+/** Haversine formula — returns distance in metres between two lat/lon points. */
+private BigDecimal haversineDistance(BigDecimal lat1, BigDecimal lon1, BigDecimal lat2, BigDecimal lon2) {
+    final double R = 6_371_000.0  // Earth radius in metres
+    double dLat = Math.toRadians((lat2 - lat1).doubleValue())
+    double dLon = Math.toRadians((lon2 - lon1).doubleValue())
+    double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+               Math.cos(Math.toRadians(lat1.doubleValue())) *
+               Math.cos(Math.toRadians(lat2.doubleValue())) *
+               Math.sin(dLon / 2) * Math.sin(dLon / 2)
+    double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+    return new BigDecimal(R * c)
 }
 
 // ---------------------------------------------------------------------------

--- a/drivers/FordPassVehicle.groovy
+++ b/drivers/FordPassVehicle.groovy
@@ -274,9 +274,9 @@ private void parseMetrics(def metrics) {
     safeVal(metrics, "deepSleepStatus")  { v -> sendEvent(name: "deepSleepMode",     value: v?.toString()) }
 
     safeVal(metrics, "oilLifeRemaining") { v -> sendEvent(name: "oilLife",           value: v as BigDecimal, unit: "%") }
-    safeVal(metrics, "ambientTemp")      { v -> if ((v as BigDecimal) != 0) sendEvent(name: "temperature",        value: v as BigDecimal, unit: "°C") }
-    safeVal(metrics, "engineOilTemp")    { v -> if ((v as BigDecimal) != 0) sendEvent(name: "engineOilTemp",      value: v as BigDecimal, unit: "°C") }
-    safeVal(metrics, "coolantTemp")      { v -> if ((v as BigDecimal) != 0) sendEvent(name: "engineCoolantTemp",  value: v as BigDecimal, unit: "°C") }
+    safeVal(metrics, "ambientTemp")      { v -> if ((v as BigDecimal) != 0) sendEvent(name: "temperature",        value: convertTemperature(v), unit: "°${location.temperatureScale}") }
+    safeVal(metrics, "engineOilTemp")    { v -> if ((v as BigDecimal) != 0) sendEvent(name: "engineOilTemp",      value: convertTemperature(v), unit: "°${location.temperatureScale}") }
+    safeVal(metrics, "coolantTemp")      { v -> if ((v as BigDecimal) != 0) sendEvent(name: "engineCoolantTemp",  value: convertTemperature(v), unit: "°${location.temperatureScale}") }
     safeVal(metrics, "vehicleSpeed")     { v -> sendEvent(name: "speed",              value: v as BigDecimal) }
 
     // --- Array metrics ---
@@ -440,6 +440,15 @@ private BigDecimal convertPressure(def kPaValue, String targetUnit) {
         case "BAR":  return (kPa / 100).setScale(2, BigDecimal.ROUND_HALF_UP)
         default:     return kPa.setScale(1, BigDecimal.ROUND_HALF_UP)  // kPa
     }
+}
+
+/** Ford API returns temperatures in Celsius; convert to hub's preferred scale. */
+private BigDecimal convertTemperature(def celsiusValue) {
+    BigDecimal c = celsiusValue as BigDecimal
+    if (location.temperatureScale == "F") {
+        return (c * 9 / 5 + 32).setScale(1, BigDecimal.ROUND_HALF_UP)
+    }
+    return c.setScale(1, BigDecimal.ROUND_HALF_UP)
 }
 
 /** Haversine formula — returns distance in metres between two lat/lon points. */

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,22 @@
-# Moen Flo for Hubitat
+# Hubitat Apps & Drivers by David Manuel
 
-Groovy drivers and apps that integrate [Moen FLO Smart Water](https://www.moenflo.com/) devices with a [Hubitat](https://hubitat.com/) hub. Communicates with the Moen Flo cloud API to monitor water usage, pressure, temperature, and control your shutoff valve — all from within Hubitat.
+Groovy drivers and apps for [Hubitat](https://hubitat.com/) hubs, published here and distributed via [Hubitat Package Manager](https://github.com/HubitatCommunity/hubitatpackagemanager).
 
 ---
 
 ## Packages
 
-There are two packages. **MoenFloManager is recommended** for all new installs.
-
 | Package | Status | Description |
 |---|---|---|
-| [MoenFloManager](MoenFloManager/) | Active — new features | Multi-app architecture supporting all three Flo device types |
-| [MoenFloStandalone](MoenFloStandalone/) | Legacy — bug fixes only | Single standalone driver for the Smart Shutoff valve |
+| [FordPass](FordPass/) | Active | Ford/Lincoln connected vehicle integration — lock/unlock, remote start, guard mode, preconditioning, vehicle status, and optional ABRP live telemetry |
+| [MoenFloManager](MoenFloManager/) | Active — new features | Multi-app architecture supporting all three Moen Flo device types |
+| [MoenFloStandalone](MoenFloStandalone/) | Legacy — bug fixes only | Single standalone driver for the Moen Flo Smart Shutoff valve |
+
+---
+
+## Moen Flo for Hubitat
+
+Communicates with the Moen Flo cloud API to monitor water usage, pressure, temperature, and control your shutoff valve — all from within Hubitat.
 
 ---
 
@@ -143,6 +148,13 @@ DIRECTION=upload
 ## Repository Structure
 
 ```
+FordPass/
+  apps/
+    FordPassConnect.groovy
+  drivers/
+    FordPassVehicle.groovy
+  packageManifest.json
+
 MoenFloManager/
   apps/
     MoenDeviceManager.groovy
@@ -161,7 +173,7 @@ MoenFloStandalone/
     moenflodetector.groovy
   packageManifest.json
 
-tools/                              ← legacy Python toolset
+tools/                              ← legacy Python toolset (Moen packages)
 deploy.js                           ← Node.js watch/deploy script
 ```
 
@@ -169,8 +181,8 @@ deploy.js                           ← Node.js watch/deploy script
 
 ## License
 
-Moen Flo for Hubitat by [David Manuel](https://github.com/dacmanj) is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0).
+Each package is licensed individually — see the `license.txt` in its own folder. The Moen Flo packages by [David Manuel](https://github.com/dacmanj) are licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0). FordPass is a derivative of [marq24/ha-fordpass](https://github.com/marq24/ha-fordpass) and remains under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
-Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND. See the license for details.
+Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND. See each license for details.
 
-> This project is not affiliated with, endorsed by, or sponsored by Moen Inc. or Flo Technologies, Inc. All trademarks are reserved to their respective owners.
+> This project is not affiliated with, endorsed by, or sponsored by Moen Inc., Flo Technologies, Inc., Ford Motor Company, or Lincoln. All trademarks are reserved to their respective owners.

--- a/repository.json
+++ b/repository.json
@@ -21,8 +21,19 @@
       "location": "https://raw.githubusercontent.com/dacmanj/hubitat/main/MoenFloManager/packageManifest.json",
       "description": "The device manager enables quick-setup and shared credentials for all your Moen FLO devices.<br>Hubitat Integration for the Moen Flo Devices (Smart Shutoff and Smart Shutoff Valve). See readme at https://dcmanjr.com/flo",
       "tags": [
-        "Water", 
+        "Water",
         "Monitoring"
+      ]
+    },
+    {
+      "id": "2cc0fb5a-d325-4904-8831-7b049562a965",
+      "name": "FordPass Connect",
+      "category": "Integrations",
+      "location": "https://raw.githubusercontent.com/dacmanj/hubitat/main/FordPass/packageManifest.json",
+      "description": "Hubitat port of marq24/ha-fordpass. Connect Ford and Lincoln vehicles: lock/unlock, remote start, guard mode, preconditioning, door/window/tire status, GPS presence, and optional ABRP (A Better Route Planner) live telemetry push.",
+      "tags": [
+        "Vehicle",
+        "Integrations"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Migrate the Hubitat FordPass port out of the `hubitat/` directory on the `hubitat` branch of [dacmanj/ha-fordpass](https://github.com/dacmanj/ha-fordpass) (a fork of [marq24/ha-fordpass](https://github.com/marq24/ha-fordpass)) into its own package here, alongside the Moen Flo packages — this is where published apps/drivers for this hub live, and it makes the integration discoverable via Hubitat Package Manager.
- History preserved via `git subtree` (both apps/drivers commit history and the ABRP telemetry push from [dacmanj/ha-fordpass#1](https://github.com/dacmanj/ha-fordpass/pull/1) carried over).
- Adds `FordPass/packageManifest.json` and `FordPass/license.txt` (Apache 2.0, matching the upstream `marq24/ha-fordpass` license — the FordPass package keeps its own license, separate from the Moen packages' CC BY 4.0), following this repo's per-package conventions.
- Lists FordPass in the root `repository.json` (for HPM) and `readme.md`, and documents it in `CLAUDE.md`.
- **Namespace unchanged**: the Groovy files keep the `fordpass-hubitat` namespace (not `dacmanj`) to avoid orphaning any already-installed instance on a live hub.

## Package contents
- `FordPass/apps/FordPassConnect.groovy` — OAuth PKCE flow, token management, API polling, child device creation, optional ABRP (A Better Route Planner) live telemetry push
- `FordPass/drivers/FordPassVehicle.groovy` — child device driver: lock/unlock, remote start, guard mode, preconditioning, door/window/tire status, GPS presence
- `FordPass/readme.md` — install instructions (HPM + manual), setup, supported vehicles, attributes/commands reference

## Test plan
- [ ] Install via HPM using this branch's `repository.json`/`packageManifest.json` (or manually import both `.groovy` files) on a test hub and confirm the app/driver install cleanly
- [ ] Confirm an existing installed instance (if any) still resolves correctly given the unchanged `fordpass-hubitat` namespace
- [ ] Spot-check rendered `readme.md` links (raw GitHub URLs point at `main`, will resolve once merged)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01K5fNYVuHR473cqRtioKFRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5fNYVuHR473cqRtioKFRQ)_