### PR TITLE
Move ABRP telemetry push from app to device driver

### DIFF
--- a/FordPass/apps/FordPassConnect.groovy
+++ b/FordPass/apps/FordPassConnect.groovy
@@ -53,12 +53,6 @@ definition(
 @Field String AUTONOMIC_API_URL      = "https://api.autonomic.ai/v1"
 @Field String AUTONOMIC_BETA_API_URL = "https://api.autonomic.ai/v1beta"
 
-// ABRP's public "Generic" telemetry API key — shared by DIY/generic telemetry
-// integrations that don't register their own app with Iternio. Paired with a
-// per-vehicle "Generic" token obtained from the ABRP app (Vehicle → Live Data → Generic).
-@Field String ABRP_API_KEY       = "32b2162f-9599-4647-8139-66e9f9528370"
-@Field String ABRP_TELEMETRY_URL = "https://api.iternio.com/1/tlm/send"
-
 // Default HTTP headers matching the FordPass Android app (okhttp/4.12.0)
 @Field Map DEFAULT_HEADERS = [
     "Accept-Encoding": "gzip",
@@ -238,29 +232,6 @@ def mainPage() {
                 defaultValue: "5",
                 required:     true
             )
-        }
-
-        section("ABRP (A Better Route Planner) Live Data") {
-            input(
-                name:           "abrpEnabled",
-                type:           "bool",
-                title:          "Push live telemetry to ABRP",
-                defaultValue:   false,
-                submitOnChange: true
-            )
-            if (settings.abrpEnabled) {
-                paragraph(
-                    "In the ABRP app: open your vehicle → <b>Live Data</b> → link it using the " +
-                    "<b>Generic</b> connection method, then paste the token it gives you below. " +
-                    "Telemetry is pushed to ABRP every time this app polls the vehicle (see Polling Interval above)."
-                )
-                input(
-                    name:     "abrpToken",
-                    type:     "text",
-                    title:    "ABRP Generic Token",
-                    required: true
-                )
-            }
         }
 
         section("Logging") {
@@ -809,85 +780,6 @@ void pollVehicle() {
         child.parseVehicleData(data)
     } else {
         logWarn("pollVehicle: child device not found for VIN ${state.vin}")
-    }
-
-    pushAbrpTelemetry(data)
-}
-
-// ---------------------------------------------------------------------------
-// ABRP (A Better Route Planner) live telemetry
-// ---------------------------------------------------------------------------
-
-/**
- * Push live telemetry to ABRP after a successful poll.
- *
- * Reads directly from the raw Autonomic metrics (not the driver's converted,
- * unit-scaled attributes) so ABRP always gets km/h, %, and Celsius regardless
- * of the driver's distance/temperature preferences.
- *
- * Mirrors the request shape used by Iternio's own reference client
- * (github.com/iternio/autopi-link): a GET to /1/tlm/send with api_key, token,
- * and a compact JSON "tlm" object all in the query string.
- */
-void pushAbrpTelemetry(Map rawData) {
-    if (!settings.abrpEnabled) return
-    if (!settings.abrpToken) {
-        logWarn("pushAbrpTelemetry: ABRP push enabled but no token configured — skipping")
-        return
-    }
-
-    Map metrics = rawData?.metrics ?: [:]
-    Map tlm = [utc: (long)(new Date().time / 1000)]
-
-    def soc = metrics.xevBatteryStateOfCharge?.value
-    if (soc != null) tlm.soc = soc as BigDecimal
-
-    def speed = metrics.vehicleSpeed?.value
-    if (speed != null) tlm.speed = speed as BigDecimal
-
-    def loc = metrics.position?.value?.location
-    def lat = loc?.lat ?: loc?.latitude
-    def lon = loc?.lon ?: loc?.longitude
-    if (lat != null && lon != null) {
-        tlm.lat = lat as BigDecimal
-        tlm.lon = lon as BigDecimal
-    }
-
-    // Ford API returns 0 for "no sensor reading" as well as a genuine 0°C — same
-    // convention the driver uses for ambientTemp, so treat 0 as "unavailable" here too.
-    def extTemp = metrics.ambientTemp?.value
-    if (extTemp != null && (extTemp as BigDecimal) != 0) tlm.ext_temp = extTemp as BigDecimal
-
-    String chargeStatus = metrics.xevBatteryChargeDisplayStatus?.value?.toString()
-    if (chargeStatus != null) tlm.is_charging = (chargeStatus == "IN_PROGRESS") ? 1 : 0
-
-    String ignition = metrics.ignitionStatus?.value?.toString()?.toUpperCase()
-    if (ignition != null) tlm.is_parked = (ignition in ["START", "RUN"]) ? 0 : 1
-
-    if (tlm.soc == null && tlm.lat == null) {
-        logDebug("pushAbrpTelemetry: no usable telemetry fields in this poll — skipping")
-        return
-    }
-
-    String tlmJson = JsonOutput.toJson(tlm)
-    String url = "${ABRP_TELEMETRY_URL}?api_key=${java.net.URLEncoder.encode(ABRP_API_KEY, 'UTF-8')}" +
-                 "&token=${java.net.URLEncoder.encode(settings.abrpToken as String, 'UTF-8')}" +
-                 "&tlm=${java.net.URLEncoder.encode(tlmJson, 'UTF-8')}"
-
-    try {
-        httpGet([uri: url]) { resp ->
-            if (resp.status == 200) {
-                logDebug("pushAbrpTelemetry: OK — ${tlmJson}")
-            } else {
-                logWarn("pushAbrpTelemetry: HTTP ${resp.status} — ${resp.data}")
-            }
-        }
-    } catch (groovyx.net.http.HttpResponseException e) {
-        String errBody = ""
-        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
-        logError("pushAbrpTelemetry: HTTP ${e.statusCode} — ${errBody ?: e.message}")
-    } catch (Exception e) {
-        logError("pushAbrpTelemetry: ${e.message}")
     }
 }
 

--- a/FordPass/drivers/FordPassVehicle.groovy
+++ b/FordPass/drivers/FordPassVehicle.groovy
@@ -28,6 +28,14 @@
  */
 
 import groovy.json.JsonSlurper
+import groovy.json.JsonOutput
+import groovy.transform.Field
+
+// ABRP's public "Generic" telemetry API key — shared by DIY/generic telemetry
+// integrations that don't register their own app with Iternio. Paired with a
+// per-vehicle "Generic" token obtained from the ABRP app (Vehicle → Live Data → Generic).
+@Field String ABRP_API_KEY       = "32b2162f-9599-4647-8139-66e9f9528370"
+@Field String ABRP_TELEMETRY_URL = "https://api.iternio.com/1/tlm/send"
 
 metadata {
     definition(
@@ -117,6 +125,21 @@ metadata {
         input(name: "distanceUnit",    type: "enum",   title: "Distance unit",
               options: ["km": "km", "miles": "miles"], defaultValue: "miles")
         input(name: "geofenceRadius",  type: "number", title: "Home geofence radius (metres)", defaultValue: 200)
+        input(
+            name:           "abrpEnabled",
+            type:           "bool",
+            title:          "Push live telemetry to ABRP (A Better Route Planner)",
+            defaultValue:   false,
+            submitOnChange: true
+        )
+        if (settings.abrpEnabled) {
+            input(
+                name:     "abrpToken",
+                type:     "text",
+                title:    "ABRP Generic Token — from the ABRP app: Vehicle → Live Data → Generic",
+                required: true
+            )
+        }
         input(name: "enableDebugLog",  type: "bool",   title: "Enable debug logging", defaultValue: false)
     }
 }
@@ -257,6 +280,86 @@ void parseVehicleData(Map rawData) {
         sendEvent(name: "lastUpdated", value: new Date().toString())
     } catch (Exception e) {
         logError("parseVehicleData: ${e.message}")
+    }
+
+    pushAbrpTelemetry(rawData)
+}
+
+// ---------------------------------------------------------------------------
+// ABRP (A Better Route Planner) live telemetry
+// ---------------------------------------------------------------------------
+
+/**
+ * Push live telemetry to ABRP after each poll.
+ *
+ * Reads directly from the raw Autonomic metrics (not the sendEvent-converted,
+ * unit-scaled attributes above) so ABRP always gets km/h, %, and Celsius
+ * regardless of this device's distance/temperature preferences.
+ *
+ * Mirrors the request shape used by Iternio's own reference client
+ * (github.com/iternio/autopi-link): a GET to /1/tlm/send with api_key, token,
+ * and a compact JSON "tlm" object all in the query string.
+ */
+private void pushAbrpTelemetry(Map rawData) {
+    if (!settings.abrpEnabled) return
+    if (!settings.abrpToken) {
+        logWarn("pushAbrpTelemetry: ABRP push enabled but no token configured — skipping")
+        return
+    }
+
+    Map metrics = rawData?.metrics ?: [:]
+    Map tlm = [utc: (long)(new Date().time / 1000)]
+
+    def soc = metrics.xevBatteryStateOfCharge?.value
+    if (soc != null) tlm.soc = soc as BigDecimal
+
+    def speed = metrics.vehicleSpeed?.value
+    if (speed != null) tlm.speed = speed as BigDecimal
+
+    def loc = metrics.position?.value?.location
+    def lat = loc?.lat ?: loc?.latitude
+    def lon = loc?.lon ?: loc?.longitude
+    if (lat != null && lon != null) {
+        tlm.lat = lat as BigDecimal
+        tlm.lon = lon as BigDecimal
+    }
+
+    // Ford API returns 0 for "no sensor reading" as well as a genuine 0°C — same
+    // convention used elsewhere in this driver for ambientTemp, so treat 0 as
+    // "unavailable" here too.
+    def extTemp = metrics.ambientTemp?.value
+    if (extTemp != null && (extTemp as BigDecimal) != 0) tlm.ext_temp = extTemp as BigDecimal
+
+    String chargeStatus = metrics.xevBatteryChargeDisplayStatus?.value?.toString()
+    if (chargeStatus != null) tlm.is_charging = (chargeStatus == "IN_PROGRESS") ? 1 : 0
+
+    String ignition = metrics.ignitionStatus?.value?.toString()?.toUpperCase()
+    if (ignition != null) tlm.is_parked = (ignition in ["START", "RUN"]) ? 0 : 1
+
+    if (tlm.soc == null && tlm.lat == null) {
+        logDebug("pushAbrpTelemetry: no usable telemetry fields in this poll — skipping")
+        return
+    }
+
+    String tlmJson = JsonOutput.toJson(tlm)
+    String url = "${ABRP_TELEMETRY_URL}?api_key=${java.net.URLEncoder.encode(ABRP_API_KEY, 'UTF-8')}" +
+                 "&token=${java.net.URLEncoder.encode(settings.abrpToken as String, 'UTF-8')}" +
+                 "&tlm=${java.net.URLEncoder.encode(tlmJson, 'UTF-8')}"
+
+    try {
+        httpGet([uri: url]) { resp ->
+            if (resp.status == 200) {
+                logDebug("pushAbrpTelemetry: OK — ${tlmJson}")
+            } else {
+                logWarn("pushAbrpTelemetry: HTTP ${resp.status} — ${resp.data}")
+            }
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        String errBody = ""
+        try { errBody = e.response?.data?.toString() ?: "" } catch (Exception ignored) {}
+        logError("pushAbrpTelemetry: HTTP ${e.statusCode} — ${errBody ?: e.message}")
+    } catch (Exception e) {
+        logError("pushAbrpTelemetry: ${e.message}")
     }
 }
 

--- a/FordPass/readme.md
+++ b/FordPass/readme.md
@@ -52,7 +52,7 @@ After setup the app polls the Ford/Autonomic APIs on a configurable interval and
 
 ## ABRP Live Data (Optional)
 
-The app can push live telemetry to [A Better Route Planner](https://abetterrouteplanner.com) (ABRP)
+The FordPass Vehicle device can push live telemetry to [A Better Route Planner](https://abetterrouteplanner.com) (ABRP)
 on every poll, so ABRP's route/energy predictions use your vehicle's real-time SOC, position, speed,
 and charging state instead of stale data.
 
@@ -60,12 +60,13 @@ Setup:
 
 1. In the ABRP app or abetterrouteplanner.com, open your vehicle → **Live Data** → link it using the
    **Generic** connection method. ABRP gives you a token.
-2. In the FordPass Connect app's main page, enable **Push live telemetry to ABRP** and paste that
-   token into **ABRP Generic Token**.
+2. Open the **FordPass Vehicle** device's preferences (not the app), enable **Push live telemetry to
+   ABRP**, and paste that token into **ABRP Generic Token**.
 
 Telemetry (SOC, lat/lon, speed, external temperature, charging state) is sent to ABRP's telemetry
 endpoint (`api.iternio.com/1/tlm/send`) right after each scheduled poll — so the ABRP push interval
-matches your **Polling Interval** setting. No separate schedule or child device is created for this.
+matches the app's **Polling Interval** setting. This lives on the device (not the app) alongside its
+other per-vehicle preferences, like tire pressure and distance units.
 
 ---
 


### PR DESCRIPTION
## Summary
- Move the ABRP (A Better Route Planner) live telemetry push and its config (`abrpEnabled`, `abrpToken`) from `FordPassConnect.groovy` (the app) to `FordPassVehicle.groovy` (the device driver).
- Rationale: `FordPassConnect` already has `singleInstance: false` — you install one app instance per vehicle (`state.vin` is singular per instance) — so the original "avoid duplicating ABRP credentials across vehicles" justification for putting it on the app didn't actually hold. The ABRP token is a per-vehicle credential, so it now sits alongside the driver's other per-vehicle preferences (tire pressure unit, distance unit, geofence radius) instead of being the one ABRP-specific setting on the app.
- Behavior is unchanged: telemetry (SOC, lat/lon, speed, external temp, charging state) is still read from the raw Autonomic metrics and pushed right after each poll, at the same cadence as the app's polling interval — `parseVehicleData()` now triggers the push instead of `pollVehicle()`.
- Updated `FordPass/readme.md`'s ABRP section to point at the device's preferences instead of the app's main page.

## Test plan
- [ ] On a hub with an existing FordPass Vehicle device, remove any old `abrpEnabled`/`abrpToken` app settings (no longer read) and configure them on the device instead; confirm telemetry still reaches ABRP after a poll
- [ ] Confirm the app continues to work normally with no ABRP-related settings on its pages

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01K5fNYVuHR473cqRtioKFRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5fNYVuHR473cqRtioKFRQ)_