### PR TITLE
Fix NPE in FordPass Vehicle driver preferences block (v1.1.1)

### DIFF
--- a/FordPass/drivers/FordPassVehicle.groovy
+++ b/FordPass/drivers/FordPassVehicle.groovy
@@ -132,7 +132,7 @@ metadata {
             defaultValue:   false,
             submitOnChange: true
         )
-        if (settings.abrpEnabled) {
+        if (settings?.abrpEnabled) {
             input(
                 name:     "abrpToken",
                 type:     "text",

--- a/FordPass/packageManifest.json
+++ b/FordPass/packageManifest.json
@@ -1,10 +1,10 @@
 {
   "packageName": "FordPass Connect",
   "author": "David Manuel",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "minimumHEVersion": "2.3.0",
   "dateReleased": "2026-07-24",
-  "releaseNotes": "v1.1.0: Moved ABRP (A Better Route Planner) live telemetry settings from the FordPass Connect app to the FordPass Vehicle device — if you had ABRP enabled before this update, re-enable it and re-enter your token on the device's preferences page. No other changes.",
+  "releaseNotes": "v1.1.1: Fix a NullPointerException in the FordPass Vehicle driver's preferences block (settings.abrpEnabled → settings?.abrpEnabled) that could cause driver code updates to fail with \"Failed to upgrade driver\" in Hubitat Package Manager.",
   "documentationLink": "https://github.com/dacmanj/hubitat/tree/main/FordPass#readme",
   "licenseFile": "https://raw.githubusercontent.com/dacmanj/hubitat/main/FordPass/license.txt",
   "apps": [

--- a/FordPass/readme.md
+++ b/FordPass/readme.md
@@ -206,6 +206,9 @@ Originally developed in the `hubitat/` directory of [dacmanj/ha-fordpass](https:
 
 ## Release Notes
 
+- 2026-07-24 - v1.1.1
+  - Fix a `NullPointerException` in the FordPass Vehicle driver's `preferences` block (`settings.abrpEnabled` → `settings?.abrpEnabled`). This could make Hubitat Package Manager report "Failed to upgrade driver ... Be sure the package is not in use with devices" when updating from v1.1.0.
+
 - 2026-07-24 - v1.1.0
   - Moved ABRP (A Better Route Planner) live telemetry settings from the FordPass Connect app to the FordPass Vehicle device's own preferences, alongside its other per-vehicle settings (tire pressure/distance units). **If you had ABRP enabled before this update**, re-enable it and re-enter your token on the device's preferences page.
 


### PR DESCRIPTION
## Summary
- Fixes `FordPass/drivers/FordPassVehicle.groovy`'s `preferences {}` block, which used `if (settings.abrpEnabled)` to conditionally show the ABRP token field. `settings` can be `null` (not just missing a key) when Hubitat evaluates a driver's `preferences` block without a live device instance backing it — which is exactly what appears to happen during an HPM driver code update — so `settings.abrpEnabled` throws a `NullPointerException` there. Every other `settings.xxx` reference in this file runs from device-runtime methods where `settings` is always a real Map, so this was the one spot that needed the null-safe operator (`settings?.abrpEnabled`).
- This is very likely the cause of the "Failed to upgrade driver ... Be sure the package is not in use with devices" error reported when updating from v1.1.0 — HPM's generic error message doesn't surface the underlying platform exception, but I verified the file is otherwise syntactically valid (compiled clean with plain `groovyc`) and this is the one behavioral difference between the working app-based version and the driver-based version.
- Bumps `packageManifest.json` to v1.1.1 with release notes, and adds a corresponding readme entry, so HPM offers this as an update.

## Test plan
- [ ] Update FordPass Connect via HPM from v1.1.0 (or a stuck/partial install) to v1.1.1 and confirm the driver upgrades successfully this time
- [ ] Confirm the device's preferences page still renders correctly, and toggling **Push live telemetry to ABRP** still shows/hides the token field as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01K5fNYVuHR473cqRtioKFRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5fNYVuHR473cqRtioKFRQ)_