### PR TITLE
Wire up chargingPower on the FordPass Vehicle driver (v1.2.0)

### DIFF
--- a/FordPass/drivers/FordPassVehicle.groovy
+++ b/FordPass/drivers/FordPassVehicle.groovy
@@ -382,6 +382,7 @@ private void parseMetrics(def metrics) {
     safeVal(metrics, "xevBatteryRange")  { v -> sendEvent(name: "batteryRange", value: convertDistance(v), unit: settings.distanceUnit ?: "miles") }
     safeVal(metrics, "xevPlugChargerStatus")          { v -> sendEvent(name: "plugStatus",     value: v?.toString()) }
     safeVal(metrics, "xevBatteryChargeDisplayStatus") { v -> sendEvent(name: "chargingStatus", value: v?.toString()) }
+    parseChargingPower(metrics)
 
     safeVal(metrics, "ignitionStatus")   { v ->
         sendEvent(name: "ignition", value: v?.toString())
@@ -412,6 +413,42 @@ private void parseMetrics(def metrics) {
 
     // GPS: metrics.position.value.location → {lat, lon, alt}
     parsePosition(metrics.position?.value?.location)
+}
+
+/**
+ * Ford doesn't expose a "charging power" metric directly — compute it from
+ * charger voltage × current, mirroring
+ * fordpass_handler.py::_get_eleveh_charging_power_from_metrics(). Only
+ * meaningful while plugged in; there's no equivalent traction/motor power
+ * metric while driving.
+ *
+ * AC charging reports both xevBatteryChargerVoltageOutput and
+ * ...CurrentOutput. DC fast charging often reports 0 for charger current, so
+ * fall back to the battery-side xevBatteryIoCurrent (which can be negative —
+ * use its magnitude).
+ */
+private void parseChargingPower(def metrics) {
+    def voltRaw = metrics.xevBatteryChargerVoltageOutput?.value
+    def ampsRaw = metrics.xevBatteryChargerCurrentOutput?.value
+    if (voltRaw == null || ampsRaw == null) return
+
+    try {
+        BigDecimal volts = voltRaw as BigDecimal
+        BigDecimal amps  = ampsRaw as BigDecimal
+
+        BigDecimal kw
+        if (volts != 0 && amps != 0) {
+            kw = (volts * amps) / 1000
+        } else if (volts != 0 && metrics.xevBatteryIoCurrent?.value != null) {
+            BigDecimal battAmps = (metrics.xevBatteryIoCurrent.value as BigDecimal).abs()
+            kw = battAmps != 0 ? (volts * battAmps) / 1000 : 0
+        } else {
+            kw = 0
+        }
+        sendEvent(name: "chargingPower", value: kw.setScale(2, BigDecimal.ROUND_HALF_UP), unit: "kW")
+    } catch (Exception e) {
+        logDebug("parseChargingPower: ${e.message}")
+    }
 }
 
 private void parseDoorLockArray(def lockList) {

--- a/FordPass/packageManifest.json
+++ b/FordPass/packageManifest.json
@@ -1,10 +1,10 @@
 {
   "packageName": "FordPass Connect",
   "author": "David Manuel",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "minimumHEVersion": "2.3.0",
   "dateReleased": "2026-07-24",
-  "releaseNotes": "v1.1.1: Fix a NullPointerException in the FordPass Vehicle driver's preferences block (settings.abrpEnabled → settings?.abrpEnabled) that could cause driver code updates to fail with \"Failed to upgrade driver\" in Hubitat Package Manager.",
+  "releaseNotes": "v1.2.0: The chargingPower attribute is now populated (was declared but never wired up) — computed from charger voltage × current, with a DC fast-charging fallback. Only available while plugged in; Ford's API has no equivalent power metric while driving.",
   "documentationLink": "https://github.com/dacmanj/hubitat/tree/main/FordPass#readme",
   "licenseFile": "https://raw.githubusercontent.com/dacmanj/hubitat/main/FordPass/license.txt",
   "apps": [

--- a/FordPass/readme.md
+++ b/FordPass/readme.md
@@ -68,6 +68,13 @@ endpoint (`api.iternio.com/1/tlm/send`) right after each scheduled poll — so t
 matches the app's **Polling Interval** setting. This lives on the device (not the app) alongside its
 other per-vehicle preferences, like tire pressure and distance units.
 
+**About ABRP's "reference consumption confidence":** we intentionally don't send a `power` field.
+ABRP's consumption model is calibrated primarily from live power draw while driving, and Ford's API
+doesn't expose that for the Mach-E (or any Ford EV) — only SOC. ABRP will show a lower confidence
+percentage for this reason; it's a limitation of what Ford's API exposes, not something this
+integration can improve, and it will slowly climb as ABRP accumulates more SOC-vs-distance data
+across trips.
+
 ---
 
 ## Supported Vehicles
@@ -205,6 +212,9 @@ Originally developed in the `hubitat/` directory of [dacmanj/ha-fordpass](https:
 ---
 
 ## Release Notes
+
+- 2026-07-24 - v1.2.0
+  - `chargingPower` is now populated (previously declared but never wired up) — computed from `xevBatteryChargerVoltageOutput` × `xevBatteryChargerCurrentOutput`, falling back to `xevBatteryIoCurrent` for DC fast charging. Only available while plugged in; Ford's API doesn't expose an equivalent power metric while driving, so this doesn't change ABRP's live-data consumption confidence — see [ABRP Live Data](#abrp-live-data-optional).
 
 - 2026-07-24 - v1.1.1
   - Fix a `NullPointerException` in the FordPass Vehicle driver's `preferences` block (`settings.abrpEnabled` → `settings?.abrpEnabled`). This could make Hubitat Package Manager report "Failed to upgrade driver ... Be sure the package is not in use with devices" when updating from v1.1.0.


### PR DESCRIPTION
## Summary
- `chargingPower` has been a declared attribute on `FordPassVehicle.groovy` since the initial port, but `parseMetrics()` never actually populated it — dead stub.
- Wires it up: adds `parseChargingPower(metrics)`, computing kW from `xevBatteryChargerVoltageOutput × xevBatteryChargerCurrentOutput`, matching `fordpass_handler.py::_get_eleveh_charging_power_from_metrics()` in the Python reference implementation. Falls back to the battery-side `xevBatteryIoCurrent` (using its magnitude) when charger current output is 0, which covers DC fast charging.
- Only populated while plugged in — Ford's Autonomic API has no equivalent power metric while driving (no traction/motor power field exists at all), so this doesn't change what's sent to ABRP's telemetry push or improve ABRP's "reference consumption confidence" rating, which is calibrated from driving power draw specifically. Documented that limitation in the readme's ABRP section so it's not mistaken for a bug.
- Bumps to v1.2.0 with release notes.

## Test plan
- [ ] Confirm `chargingPower` reports a sane kW value on the device while charging (AC and, if testable, DC fast charging)
- [ ] Confirm it stays unset/unchanged while driving or idle unplugged (no bogus 0 spam on every poll — only sent when both charger metrics are present)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01K5fNYVuHR473cqRtioKFRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5fNYVuHR473cqRtioKFRQ)_