### PR TITLE
Fix logout/login lockout caused by spurious auth failure

### DIFF
--- a/MoenFloManager/apps/MoenDeviceManager.groovy
+++ b/MoenFloManager/apps/MoenDeviceManager.groovy
@@ -224,7 +224,6 @@ def authenticate() {
     def uri = AUTH_URL
     if (!password) {
         log.info("Login Skipped: No password")
-        state.authenticationFailures = 99
         return
     }
     if (state.authenticationFailures >= 3) {

--- a/MoenFloManager/packageManifest.json
+++ b/MoenFloManager/packageManifest.json
@@ -1,10 +1,10 @@
 {
   "packageName": "Moen FLO Device Manager",
   "author": "David Manuel",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "minimumHEVersion": "2.1.9",
-  "dateReleased": "2026-06-05",
-  "releaseNotes": "v1.0.18: Migrates to Moen OAuth2 API. Existing installs self-heal on first poll — no manual reauthentication required. Fixes sleep mode 400 error. Sleep revert time restricted to valid values (2h/24h/72h). Fixes logout button text color.\n\nSee full release notes at https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#release-notes",
+  "dateReleased": "2026-08-22",
+  "releaseNotes": "v1.0.19: Fixes a bug where logging out (or loading the login page with no password yet) falsely set the authentication failure count, showing a spurious \"Invalid credentials\" error and blocking the next real login attempt.\n\nSee full release notes at https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#release-notes",
   "communityLink": "https://community.hubitat.com/t/moen-flo-virtual-device/9677",
   "documentationLink": "https://github.com/dacmanj/hubitat/tree/main/MoenFloManager#readme",
   "licenseFile": "https://raw.githubusercontent.com/dacmanj/hubitat/main/MoenFloManager/license.txt",

--- a/MoenFloManager/readme.md
+++ b/MoenFloManager/readme.md
@@ -42,6 +42,10 @@ This project is not affiliated with, endorsed or sponsored by Moen Inc nor Flo T
 All trademarks are reserved to their respective owners.
 
 ## Release Notes
+- 2026-08-22 - v1.0.19
+  - Fix login page falsely reporting "Invalid credentials" after logout or on first load with no password entered yet
+  - Fix resulting lockout that blocked the next real login attempt from ever calling the Moen API
+
 - 2026-06-05 - v1.0.18
   - Migrate authentication to Moen OAuth2 API (`/api/v1/oauth2/token`), replacing the deprecated login endpoint
   - Add token refresh using OAuth2 refresh token with automatic fallback to full re-authentication


### PR DESCRIPTION
## Summary
- `authenticate()` set `state.authenticationFailures = 99` whenever the password field was empty, meant as a "no attempt made" sentinel — but it tripped the same `>= 3` lockout used for genuinely failed logins.
- Since `mainPage()` re-runs `authenticate()` on every redraw (including immediately after `logout()`, which clears the password), this made the "Invalid credentials" error banner reappear right after logging out, and permanently blocked the next real login attempt from reaching the Moen OAuth endpoint until the failure counter happened to reset in a way that stuck.
- Fix: the "no password yet" branch now just logs and returns, without touching `authenticationFailures`.
- Bumped `MoenFloManager` to v1.0.19 with release notes in `packageManifest.json` and `readme.md`.

## Test plan
- [ ] Deploy to hub (`npm run deploy`)
- [ ] Load the Moen FLO Device Manager app fresh (or after logout) — confirm no "Invalid credentials" banner appears before any login attempt
- [ ] Click Logout, confirm the login form returns clean with no error
- [ ] Enter valid credentials, click Login, confirm authentication actually succeeds
- [ ] Enter invalid credentials 3x, confirm the real lockout ("Failed to authenticate after three tries") still triggers as expected

https://claude.ai/code/session_01RpPboS7nYmaVvV7gUmoAtN