### PR TITLE
Simplify water-state mapping to a ternary

### DIFF
--- a/MoenFloManager/drivers/MoenSmartWaterDetector.groovy
+++ b/MoenFloManager/drivers/MoenSmartWaterDetector.groovy
@@ -84,10 +84,7 @@ def getDeviceInfo() {
     sendEvent(name: "humidity", value: round(deviceInfo?.telemetry?.current?.humidity, 0), unit: "%rh")
     sendEvent(name: "battery", value: round(deviceInfo?.battery?.level, 0), unit: "%")
     def water_state = deviceInfo?.fwProperties?.telemetry_water
-    def WATER_STATES = [1: "wet", 2: "dry"]
-    if (water_state) {
-        sendEvent(name: "water", value: WATER_STATES[1])}
-    else { sendEvent(name: "water", value: WATER_STATES[2])}
+    sendEvent(name: "water", value: water_state ? "wet" : "dry")
     sendEvent(name: "updated", value: deviceInfo?.telemetry?.current?.updated)
     sendEvent(name: "rssi", value: deviceInfo?.fwProperties?.telemetry_rssi)
     sendEvent(name: "ssid", value: deviceInfo?.fwProperties?.wifi_sta_ssid)

--- a/MoenFloStandalone/drivers/moenflodetector.groovy
+++ b/MoenFloStandalone/drivers/moenflodetector.groovy
@@ -119,10 +119,7 @@ def getDeviceInfo() {
         sendEvent(name: "humidity", value: round(data?.telemetry?.current?.humidity, 0), unit: "%")
         sendEvent(name: "battery", value: round(data?.battery?.level, 0), unit: "%")
         def water_state = data?.fwProperties?.telemetry_water
-        def WATER_STATES = [1: "wet", 2: "dry"]
-        if (water_state) {
-            sendEvent(name: "water", value: WATER_STATES[1])}
-        else { sendEvent(name: "water", value: WATER_STATES[2])}            
+        sendEvent(name: "water", value: water_state ? "wet" : "dry")
         sendEvent(name: "updated", value: data?.telemetry?.current?.updated)
         sendEvent(name: "rssi", value: data?.fwProperties?.telemetry_rssi)
         sendEvent(name: "ssid", value: data?.fwProperties?.wifi_sta_ssid)


### PR DESCRIPTION
## Summary
- `WATER_STATES` was a `[1: "wet", 2: "dry"]` map that looked like it indexed by an enum-style status code, but the `if`/`else` only ever read fixed keys (`1` in the truthy branch, `2` in the falsy branch) — it never actually looked `water_state` up in the map.
- The real Flo API sends `telemetry_water` as a plain boolean (confirmed via a captured `/devices/{id}` response), so the branch condition already did all the real work. Replaced with `water_state ? "wet" : "dry"` in both `MoenFloManager/drivers/MoenSmartWaterDetector.groovy` and `MoenFloStandalone/drivers/moenflodetector.groovy`.
- No behavior change — verified via `MoenSmartWaterDetectorSpec` (see #15) and manual deploy to a live hub.

## Test plan
- [x] `MoenSmartWaterDetectorSpec` passes for both `telemetry_water: true` → "wet" and `telemetry_water: false` → "dry"
- [x] Deployed to a live hub via `npm run deploy` and confirmed no change in reported state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpPboS7nYmaVvV7gUmoAtN