### PR TITLE
ci: bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,23 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run tests
         run: ./gradlew test --console=plain
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-report
           path: build/reports/tests/test


### PR DESCRIPTION
## Summary
Fixes the deprecation warnings from the first `Groovy Unit Tests` run on main:
- `setup-java@v4` deprecated → bumped to `@v5`
- `checkout@v4`, `upload-artifact@v4`, `gradle/actions/setup-gradle@v4` were old enough to get forced onto a newer Node.js runtime than they target → bumped to their current majors (`@v7`, `@v7`, `@v6`)

## Test plan
- [x] CI run on this PR should complete with no deprecation annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpPboS7nYmaVvV7gUmoAtN